### PR TITLE
#22 feat: json config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ else()
     endif()
 endif()
 
+set(configDir "${CMAKE_SOURCE_DIR}/conf" CACHE PATH "Path to the configuration file directory")
+set(romsDir "${CMAKE_SOURCE_DIR}/roms" CACHE PATH "Path to the roms directory")
+
 project(${projectName})
 
 add_executable(${projectName}
@@ -53,11 +56,13 @@ add_executable(${projectName}
     source/MemoryController.cpp
 )
 
-target_compile_definitions(${projectName} PRIVATE ROMS_DIR=\"${CMAKE_SOURCE_DIR}/roms/\")
+target_compile_definitions(${projectName} PRIVATE ROMS_DIR=\"${romsDir}\")
 
+find_package(nlohmann_json)
 find_library(libMachEmu MachEmu)
+target_compile_definitions(${projectName} PRIVATE CONFIG_DIR=\"${configDir}\")
 target_include_directories(${projectName} PRIVATE ${machEmuIncludePath} ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(${projectName} PRIVATE ${libMachEmu})
+target_link_libraries(${projectName} PRIVATE ${libMachEmu} nlohmann_json::nlohmann_json)
 
 if(enableSdl)
     find_library(libSDL2 SDL2)

--- a/conf/config.json
+++ b/conf/config.json
@@ -1,0 +1,5 @@
+{
+    "bpp": 8,
+    "colour": "white",
+    "orientation": "upright"
+}

--- a/include/SpaceInvaders/IoController.h
+++ b/include/SpaceInvaders/IoController.h
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <memory>
 
 #include "Base/Base.h"
+#include "nlohmann/json_fwd.hpp"
 #include "SpaceInvaders/MemoryController.h"
 
 namespace SpaceInvaders
@@ -85,6 +86,9 @@ namespace SpaceInvaders
 		//cppcheck-suppress unusedStructMember
 		uint8_t port5Byte_{};
 
+		// vram foregound colour
+		uint8_t colour_{ 0xFF };
+
 	protected:
 		/** The maximum number of output audio sample files.
 
@@ -115,19 +119,19 @@ namespace SpaceInvaders
 		*/
 		std::array<const char*, totalWavFiles_> wavFiles_ 
 		{
-			ROMS_DIR"ufo_highpitch.wav",	/**< UFO */
-			ROMS_DIR"shoot.wav",			/**< Player fire */
-			ROMS_DIR"explosion.wav",		/**< Player killed */
-			ROMS_DIR"invaderkilled.wav",	/**<	Invader killed */
+			ROMS_DIR"/ufo_highpitch.wav",	/**< UFO */
+			ROMS_DIR"/shoot.wav",			/**< Player fire */
+			ROMS_DIR"/explosion.wav",		/**< Player killed */
+			ROMS_DIR"/invaderkilled.wav",	/**<	Invader killed */
 			nullptr,						/**< Extended Play */
 			nullptr,						/**< AMP Enable */
 			nullptr,						/**< Unused */
 			nullptr,						/**< Unused */
-			ROMS_DIR"fastinvader1.wav",		/**< Invader fleet movement 1 */
-			ROMS_DIR"fastinvader2.wav",		/**< Invader fleet movement 1 */
-			ROMS_DIR"fastinvader3.wav",		/**< Invader fleet movement 1 */
-			ROMS_DIR"fastinvader4.wav",		/**< Invader fleet movement 1 */
-			ROMS_DIR"ufo_lowpitch.wav",		/**< UFO hit */
+			ROMS_DIR"/fastinvader1.wav",		/**< Invader fleet movement 1 */
+			ROMS_DIR"/fastinvader2.wav",		/**< Invader fleet movement 1 */
+			ROMS_DIR"/fastinvader3.wav",		/**< Invader fleet movement 1 */
+			ROMS_DIR"/fastinvader4.wav",		/**< Invader fleet movement 1 */
+			ROMS_DIR"/ufo_lowpitch.wav",		/**< UFO hit */
 			nullptr,						/**< Unused */
 			nullptr,						/**< Unused */
 			nullptr							/**< Unused */
@@ -141,7 +145,7 @@ namespace SpaceInvaders
 
 			@param		memoryController	The memory controller where the video ram resides.
 		*/
-		explicit IoController(const std::shared_ptr<MemoryController>& memoryController);
+		IoController(const std::shared_ptr<MemoryController>& memoryController, const nlohmann::json& config);
 
 		/** Read from controller.
 

--- a/include/SpaceInvaders/MemoryController.h
+++ b/include/SpaceInvaders/MemoryController.h
@@ -106,7 +106,7 @@ namespace SpaceInvaders
 
                 @see framePool_
             */
-            MemoryController(int framePoolSize = 1);
+            explicit MemoryController(int framePoolSize = 1);
 
             ~MemoryController() = default;
 

--- a/include/SpaceInvaders/SdlIoController.h
+++ b/include/SpaceInvaders/SdlIoController.h
@@ -87,7 +87,7 @@ namespace SpaceInvaders
 			
 				Creates an SDL specific Space Invaders IO controller.
 			*/
-			explicit SdlIoController(const std::shared_ptr<MemoryController>& memoryController);
+			SdlIoController(const std::shared_ptr<MemoryController>& memoryController, const nlohmann::json& config);
 			
 			/** Destructor.
 			

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -27,8 +27,8 @@ SOFTWARE.
 
 namespace SpaceInvaders
 {
-    SdlIoController::SdlIoController(const std::shared_ptr<MemoryController>& memoryController)
-		: IoController(memoryController)
+    SdlIoController::SdlIoController(const std::shared_ptr<MemoryController>& memoryController, const nlohmann::json& config)
+		: IoController(memoryController, config)
 	{
 		SDL_SetMainReady();
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -21,24 +21,25 @@ SOFTWARE.
 */
 
 #include <future>
+#include <fstream>
 #include <memory>
 #include "Machine/MachineFactory.h"
+#include "nlohmann/json.hpp"
 #include "SpaceInvaders/SdlIoController.h"
-
-//Just to make things simpler
-using namespace SpaceInvaders;
-using namespace MachEmu;
 
 int main(void)
 {
 	try
 	{
+		std::ifstream fin(CONFIG_DIR"/config.json");
+		const nlohmann::json config = nlohmann::json::parse(fin);
+
 		//The machine to run Space Invaders on.
-		auto machine = Make8080Machine();
+		auto machine = MachEmu::Make8080Machine();
 		//Create our custom Space Invaders memory controller.
-		auto memoryController = std::make_shared<MemoryController>();
+		auto memoryController = std::make_shared<SpaceInvaders::MemoryController>();
 		//Create our custom Space Invaders I/O controller.
-		auto ioController = std::make_shared<SdlIoController>(memoryController);
+		auto ioController = std::make_shared<SpaceInvaders::SdlIoController>(memoryController, config);
 
 		/*
 			Load the ROM into memory, the layout
@@ -49,10 +50,10 @@ int main(void)
 				invaders-f 1000-17FF
 				invaders-e 1800-1FFF
 		*/
-		memoryController->Load(ROMS_DIR"invaders-h.bin", 0x0000);
-		memoryController->Load(ROMS_DIR"invaders-g.bin", 0x0800);
-		memoryController->Load(ROMS_DIR"invaders-f.bin", 0x1000);
-		memoryController->Load(ROMS_DIR"invaders-e.bin", 0x1800);
+		memoryController->Load(ROMS_DIR"/invaders-h.bin", 0x0000);
+		memoryController->Load(ROMS_DIR"/invaders-g.bin", 0x0800);
+		memoryController->Load(ROMS_DIR"/invaders-f.bin", 0x1000);
+		memoryController->Load(ROMS_DIR"/invaders-e.bin", 0x1800);
 
 		// Load our controllers into the machine.
 		machine->SetMemoryController(memoryController);


### PR DESCRIPTION
A json config file has been added which uses [nlohmann json](https://github.com/nlohmann/json) for the parsing, therefore it needs to be installed otherwise compilation will fail.

The following options are available (each set to proper defaults):

```
{
    "bpp": 8,
    "colour": "white",
    "orientation": "upright"
}
```

`bpp`: bits per pixel, two values are supported: 1 - native 1bpp, 8: decompressed 8bpp.
`colour`: the foreground colour (the background colour will always be black). This can be set to an 8 bit hex colour value ("AA" for example) or one of the following pre-set values: "red", "green", "blue", "white", "random".
`orientation`: "cocktail" for horizontal (native) position or "upright" for vertical position.

Currently, the bpp and orientation options are unused.

An exception will be thrown if any of the supported options can't be parsed, unknown options are ignored.