### PR TITLE
#55 chore: update to mach_emu 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 0.5.0 [24/06/24]
-* Updated to mach-emu-1.6.0.
+* Updated to mach-emu-1.6.1.
 * Using Conan package manager.
 * Added CPack support for binary distributions.
 * Updated the JSON config file for improved flexibility.

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ class MachuEmuPackageTest(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     def requirements(self):
-        self.requires("mach_emu/1.6.0")
+        self.requires("mach_emu/1.6.1")
         self.requires("nlohmann_json/3.11.3")
         self.requires("popl/1.3.0")
         self.requires("sdl/2.28.5")


### PR DESCRIPTION
Update to the latest mach-emu version.