### PR TITLE
#81 fix: incorrect 16 bit blit

### DIFF
--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -352,7 +352,7 @@ namespace i8080_arcade
 
 										if (SDL_LockTexture(texture_, nullptr, std::bit_cast<void**>(&dst), &rowBytes) == 0)
 										{
-											i8080ArcadeIO_->BlitVRAM(std::span(dst, i8080ArcadeIO_->GetVRAMWidth() * i8080ArcadeIO_->GetVRAMHeight()), rowBytes, std::span(*videoFrame));
+											i8080ArcadeIO_->BlitVRAM(std::span(dst, i8080ArcadeIO_->GetVRAMHeight() * rowBytes), rowBytes, std::span(*videoFrame));
 											SDL_UnlockTexture(texture_);
 										}
 										else


### PR DESCRIPTION
The span sent to the blit routine was not spanning the entire texture, this caused the rendering in 16 bit mode to be incorrect.