### PR TITLE
#83 perf: triple buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,11 @@ These settings apply to the various arcade roms that can be loaded.
 
 These settings affect visual output and can be changed. They apply to all game roms loaded.
 
-`bpp:8` - Bits per pixel, supported values are 1 (currently not supported via the SDL IO controller), 8 (rgb332, not supported via the RP IO Controller) and 16 (rgb565).<br>
-`colour:white`: the forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and an 16 bit custom hex value.<br>
+`bpp:8` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
+`colour:white`: the forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and a 16 bit custom hex value.<br>
 `orientation:upright` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
+
+**NOTE**: the RP IO Controller only supports cocktail orientation @ 16bpp.
 
 ##### Audio
 
@@ -259,7 +261,7 @@ These settings affect audio output. They can be changed if different audio sampl
 
 **NOTE**: the position of the audio files in the array **must** not be changed.<br>
 **NOTE**: if changing the audio files, the audio hardware properties may need to be updated (untested).
-**NOTE**: the RP IO Controller does not support audio, these setting has no affect.
+**NOTE**: the RP IO Controller does not support audio, these setting have no affect.
 
 ##### Space Invaders/Space Invaders Deluxe/Space Invaders II/Balloon Bomber/Lunar Rescue
 

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -118,7 +118,7 @@ namespace i8080_arcade
 
             Write a command to the LCD driver.
         */
-        void WriteCmd(uint8_t cmd);
+        static void WriteCmd(uint8_t cmd);
 
         /** LCD params
 
@@ -127,7 +127,7 @@ namespace i8080_arcade
             @param    param    The next parameter in the parameter sequence defined
                                by the previous call to WriteCmd.
         */
-        void WriteParam(uint8_t param);
+        static void WriteParam(uint8_t param);
 
         /** Ram write region
 
@@ -138,7 +138,7 @@ namespace i8080_arcade
             @param    endX      the ending x coordinate of the blit region.
             @param    endX      the ending x coordinate of the blit region.
         */
-        void SetRegion(uint16_t Xstart, uint16_t Ystart, uint16_t Xend, uint16_t Yend);
+        static void SetRegion(uint16_t Xstart, uint16_t Ystart, uint16_t Xend, uint16_t Yend);
 
     public:
         /** Initialisation constructor

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -157,8 +157,8 @@ int main(int argc, char** argv)
 
     // Create our custom i8080 arcade machine
     auto machine = MachEmu::MakeMachine(meenConfig.c_str());
-    // Create our custom i8080 arcade memory controller. Two video frames for double buffering.
-    auto memoryController = std::make_shared<i8080_arcade::MemoryController>(2);
+    // Create our custom i8080 arcade memory controller. Three video frames for triple buffering.
+    auto memoryController = std::make_shared<i8080_arcade::MemoryController>(3);
 #ifdef ENABLE_MH_RP2040
     // load roms/textures/(audio samples)
     memoryController->LoadRoms(arcadeGame["memory"]["rom"]["file"]);


### PR DESCRIPTION
Using a third compressed buffer for scanline comparison, rendering only when the scanlines are different. This gets us to the required 60fps (tested against Space Invaders, Space Invaders Deluxe and Lunar Resue).