### PR TITLE
#95 feat: single thread support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   to the config file. 
 * Removed popl dependency.
 * Added IIoController base class.
+* Added single threaded support (`runAsync`,
+  `loadAsync` and `saveAsync` options can
+  be false) for demonstration purposes.
 
 0.6.1 [04/08/24]
 * Added profiles for improved build support.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ The current settings for these options should be sufficient, changing them may h
 `saveAsync:true` - Save the machine state asynchronously.<br>
 
 **NOTE**: the RP IO Controller does not support saving state.
+**NOTE**: running in synchronous mode (`runAsync` = `false`) is supported for demonstration purposes, however, it should be left to `true` for performance reasons.
+**NOTE**: running in synchronous mode (`runAsync` = `false`) requires an increase in the `isrFreq` parameter.
 
 ##### Video
 

--- a/include/i8080_arcade/IIoController.h
+++ b/include/i8080_arcade/IIoController.h
@@ -61,7 +61,7 @@ namespace i8080_arcade
 
 			@return					An error in the form of a std::error_code.
 		*/
-		virtual std::error_code LoadAudioSamples(const JsonVariant& audioSamples) = 0;
+		virtual std::error_code LoadAudioSamples(const JsonVariantConst audioSamples) = 0;
 
 		/** Load Video Textures
 
@@ -71,7 +71,7 @@ namespace i8080_arcade
 
 			@return					An error in the form of a std::error_code.
 		*/
-		virtual std::error_code LoadVideoTextures(const JsonVariant& videoTextures) = 0;
+		virtual std::error_code LoadVideoTextures(const JsonVariantConst videoTextures) = 0;
 
 		/** Load the selected rom or the save state of the currently selected rom
 			

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -98,7 +98,7 @@ namespace i8080_arcade
             This allows for a triple buffering system where the first frame is the frame
             being generated, the second frame is the frame being rendered, and the third
             frame, the back buffer, which is used to compare for scanline differences with the
-            frame being rendered. This allows for improved rendering performace by not rendering
+            frame being rendered. This allows for improved rendering performance by not rendering
             scanlines that are identical to the previous frame.
         */
         meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr backBuffer_;
@@ -163,6 +163,8 @@ namespace i8080_arcade
         bool lastK2_{};
         bool lastK3_{};
 
+        bool runAsync_{};
+
         /** LCD command
 
             Write a command to the LCD driver.
@@ -180,7 +182,7 @@ namespace i8080_arcade
 
         /** Ram write region
 
-            Define a region in display ram where pixels can be written to,
+            Define a region in display ram where pixels can be written to.
 
             @param    startX    the starting x coordinate of the blit region.
             @param    startY    the starting y coordinate of the blit region.
@@ -192,13 +194,18 @@ namespace i8080_arcade
     public:
         /** Initialisation constructor
 
-            Creates an SDL specific i8080 arcade IO controller.
+            Creates an RP2040 specific i8080 arcade IO controller.
+
+            @param		runAsync		Run this io controller asynchronously.
+            @param		audioHardware	audio hardware configuration options.
+            @param		videoHardware	video hardware configuration options.
+
         */
-        RPIoController(const JsonVariant& audioHardware, const JsonVariant& videoHardware);
+        RPIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
 
         /** Destructor
 
-            Free the various required SDL objects.
+            Free the various required RP2040 objects.
         */
         ~RPIoController();
 
@@ -246,7 +253,7 @@ namespace i8080_arcade
 
 			@return					An error in the form of a std::error_code.
         */
-        std::error_code LoadVideoTextures(const JsonVariant& videoTextures) final;
+        std::error_code LoadVideoTextures(const JsonVariantConst videoTextures) final;
 
    		/** Load Audio Samples
 
@@ -256,7 +263,7 @@ namespace i8080_arcade
 
 			@return					An error in the form of a std::error_code.
 		*/
-        std::error_code LoadAudioSamples(const JsonVariant& audioSamples) final;
+        std::error_code LoadAudioSamples(const JsonVariantConst audioSamples) final;
 
         /** Main control loop
 

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -156,12 +156,47 @@ namespace i8080_arcade
 			Uint8 lastU_{};
 			Uint8 lastY_{};
 
+			/** The running state
+			
+				True if meen is to run on a different thread to the main application,
+				false otherwise.
+			*/
+			bool runAsync_{};
+
+			/** Read input form the keyboard
+
+				@param	port	The emulated port to read from.
+				@param	state	The keyboard state.
+				
+				@return			A uint8_t bitwise combination informing the rom
+								of the user input.
+			*/
+			uint8_t ReadInputDevice(uint8_t port, const uint8_t* state);
+
+			/** Assign a load or save machine interrupt
+			
+				Peforms a check of the key once during a key press and release sequence.
+
+				@param	key				The press or release state of the key.
+				@param	lastKey			The previous press or release state of the key.
+				@param	isr				The interrupt to assign.
+				@param	loadSaveState	True if the current save state is to be loaded,
+										false otherwise.
+
+				@return					The current key state (the key parameter).
+			*/
+			Uint8 SetInterrupt(Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState);
+
 		public:
 			/** Initialisation constructor
 
 				Creates an SDL specific i8080 arcade IO controller.
+
+				@param		runAsync		Run this io controller asynchronously.
+				@param		audioHardware	audio hardware configuration options.
+				@param		videoHardware	video hardware configuration options.
 			*/
-			SDLIoController(const JsonVariant& audioHardware, const JsonVariant& videoHardware);
+			SDLIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
 
 			/** Destructor
 
@@ -175,7 +210,7 @@ namespace i8080_arcade
 
 				@param	port	The device to read from.
 
-				@return	int		A bitfield indicating the action to take.
+				@return			A bitfield indicating the action to take.
 			*/
 			uint8_t Read(uint16_t port, meen::IController* controller) final;
 
@@ -233,7 +268,7 @@ namespace i8080_arcade
 
 				@return					An error in the form of a std::error_code.
 			*/
-			std::error_code LoadAudioSamples(const JsonVariant& audioSamples) final;
+			std::error_code LoadAudioSamples(const JsonVariantConst audioSamples) final;
 
 			/** Load Video Textures
 
@@ -243,7 +278,7 @@ namespace i8080_arcade
 
 				@return					An error in the form of a std::error_code.
 			*/
-			std::error_code LoadVideoTextures(const JsonVariant& videoTextures) final;
+			std::error_code LoadVideoTextures(const JsonVariantConst videoTextures) final;
 
 			/** Load the selected rom or the save state of the currently selected rom
 			

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -437,7 +437,18 @@ namespace i8080_arcade
         auto dst = std::bit_cast<uint16_t*>(texture_.get());
         VideoFrameWrapper* vfw = nullptr;
 
-        queue_remove_blocking(&videoFrameQueue_, static_cast<void*>(&vfw));
+        if (runAsync_ == true)
+        {
+            queue_remove_blocking(&videoFrameQueue_, static_cast<void*>(&vfw));
+        }
+        else
+        {
+            if (queue_try_remove(&videoFrameQueue_, static_cast<void*>(&vfw)) == false)
+            {
+                return false;
+            }
+        }
+
         auto videoFrame = std::move(vfw->videoFrame);
         // explicitly set to nullptr as there is no requirement on std::move to do this
         vfw->videoFrame = nullptr;

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -33,7 +33,8 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    RPIoController::RPIoController(const JsonVariant& audioHardware, const JsonVariant& videoHardware)
+    RPIoController::RPIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
+        : runAsync_{ runAsync }
     {
         i8080ArcadeIO_ = meen_hw::MakeI8080ArcadeIO();
 
@@ -128,7 +129,7 @@ namespace i8080_arcade
 
         // Write 8 bits at a time
         spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
-        // Write to the whole display tp clear
+        // Write to the whole display to clear
         SetRegion(0, 0, width_, height_);
         // write to lcd ram
         WriteCmd(0X2C);
@@ -174,7 +175,7 @@ namespace i8080_arcade
         queue_free(&videoFrameQueue_);
     }
 
-    std::error_code RPIoController::LoadVideoTextures(const JsonVariant& videoTextures)
+    std::error_code RPIoController::LoadVideoTextures(const JsonVariantConst videoTextures)
     {
         int bpp = 16; // this needs to be updated to 12bpp for performance reasons
 
@@ -219,7 +220,7 @@ namespace i8080_arcade
         return std::error_code{};
     }
 
-    std::error_code RPIoController::LoadAudioSamples(const JsonVariant& audioSamples)
+    std::error_code RPIoController::LoadAudioSamples([[maybe_unused]] const JsonVariantConst audioSamples)
     {
         return std::make_error_code(std::errc::not_supported);
     }
@@ -433,55 +434,9 @@ namespace i8080_arcade
         auto arcadeWidth = i8080ArcadeIO_->GetVRAMWidth();
         auto arcadeHeight = i8080ArcadeIO_->GetVRAMHeight();
         auto compressedWidth = arcadeWidth >> 3;
-        //auto widthOffset = (width_ - arcadeWidth) / 2;
-        //auto heightOffset = (height_ - arcadeHeight) / 2;
         auto dst = std::bit_cast<uint16_t*>(texture_.get());
         VideoFrameWrapper* vfw = nullptr;
 
-	    //meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr backBuffer;
-
-        // Write 8 bits at a time
-        //spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
-        // Write to the whole display tp clear
-        //SetRegion(0, 0, width_, height_);
-        // write to lcd ram
-        //WriteCmd(0X2C);
-        // Write 16 bits at a time
-        //spi_set_format(spi1, 16, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
-
-        //gpio_put(Pin::DC, 1);
-        //gpio_put(Pin::CS, 0);
-
-        // Clear the display
-        //for(int i = 0; i < height_; i++)
-        //{
-        //     for(int j = 0; j < width_; j++)
-        //     {
-        //         uint16_t p = 0x0000;
-        //         spi_write16_blocking(spi1, &p, 1);
-        //     }
-        //}
-
-        //auto setRegion = [wo = widthOffset, ho = heightOffset, w = width_, h = height_](int hIndex)
-        //{
-        //    gpio_put(Pin::CS, 1);
-            // Write 8 bits at a time
-        //    spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
-            // Center the graphics on the display
-        //    RPIoController::SetRegion(wo, ho + hIndex, w - wo, h - ho);
-            // write to lcd ram
-        //    RPIoController::WriteCmd(0X2C);
-            // Write 16 bits at a time
-        //    spi_set_format(spi1, 16, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
-        //};
-
-        //setRegion(0);
-
-        //auto lastTime = get_absolute_time();
-        //int fr = 0;
-
-        //while(1)
-        //{
         queue_remove_blocking(&videoFrameQueue_, static_cast<void*>(&vfw));
         auto videoFrame = std::move(vfw->videoFrame);
         // explicitly set to nullptr as there is no requirement on std::move to do this

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -30,7 +30,8 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    SDLIoController::SDLIoController(const JsonVariant& audioHardware, const JsonVariant& videoHardware)
+    SDLIoController::SDLIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
+		: runAsync_{ runAsync }
 	{
 		SDL_SetMainReady();
 
@@ -130,7 +131,7 @@ namespace i8080_arcade
 		return std::tuple(loadSaveState_.exchange(false), 0);
 	}
 
-	std::error_code SDLIoController::LoadAudioSamples(const JsonVariant& audio)
+	std::error_code SDLIoController::LoadAudioSamples(const JsonVariantConst audio)
 	{
 		auto scheme = audio["scheme"].as<std::string>();
 		auto directory = audio["directory"].as<std::string>();
@@ -150,7 +151,7 @@ namespace i8080_arcade
 			return std::error_code{};
 		};
 
-		for(const auto& sample : audio["sample"].as<JsonArray>())
+		for(const auto& sample : audio["sample"].as<JsonArrayConst>())
 		{
 			auto dir = directory;
 			auto resource = sample.as<std::string>();
@@ -180,7 +181,7 @@ namespace i8080_arcade
 		return std::error_code{};
 	}
 
-	std::error_code SDLIoController::LoadVideoTextures(const JsonVariant& videoTextures)
+	std::error_code SDLIoController::LoadVideoTextures(const JsonVariantConst videoTextures)
 	{
 		std::string meenConfig;
 		serializeJson(videoTextures, meenConfig);
@@ -229,6 +230,58 @@ namespace i8080_arcade
 		return std::error_code{};
 	}
 
+	// Scan the keyboard for load and save requests
+	Uint8 SDLIoController::SetInterrupt(Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState)
+	{
+		if (key ^ lastKey && key)
+		{
+			loadSaveInterrupt_ = isr;
+			loadSaveState_ = loadSaveState;
+		}
+
+		return key;
+	}
+
+	uint8_t SDLIoController::ReadInputDevice(uint8_t port, const uint8_t* state)
+	{
+		uint8_t value = 0;
+		// We can only load from a save file or save if a rom is currently running (engine will generate an error otherwise)
+		// so we only allow the user to perform these operations when a rom is running only.
+		// (either from the Read method directly (runAsync == false) or via the Read method generating a ReadInput event (runAsync == true)
+		lastR_ = SetInterrupt(state[SDL_SCANCODE_R], lastR_, meen::ISR::Load, true);
+		lastY_ = SetInterrupt(state[SDL_SCANCODE_Y], lastY_, meen::ISR::Save, false);
+
+		if (port == 1)
+		{
+			value = 0x08;
+			value |= (state[SDL_SCANCODE_C] * 0x01); // Credit
+			value |= (state[SDL_SCANCODE_1] * 0x04); // 1P
+			value |= (state[SDL_SCANCODE_2] * 0x02); // 2P
+			value |= (state[SDL_SCANCODE_A] * 0x20); // 1P Left
+			value |= (state[SDL_SCANCODE_S] * 0x10); // 1P Fire
+			value |= (state[SDL_SCANCODE_D] * 0x40); // 1P Right
+		}
+		else if (port == 2)
+		{
+			value |= (state[SDL_SCANCODE_3] * 0x00); // 3 Ships
+			value |= (state[SDL_SCANCODE_4] * 0x01); // 4 Ships
+			value |= (state[SDL_SCANCODE_5] * 0x02); // 5 Ships
+			value |= (state[SDL_SCANCODE_6] * 0x03); // 6 Ships
+			value |= (state[SDL_SCANCODE_T] * 0x04); // Tilt
+			value |= (state[SDL_SCANCODE_E] * 0x08); // Extra Ship at
+			value |= (state[SDL_SCANCODE_J] * 0x20); // 2P Left
+			value |= (state[SDL_SCANCODE_K] * 0x10); // 2P Fire
+			value |= (state[SDL_SCANCODE_L] * 0x40); // 2P Right
+			value |= (state[SDL_SCANCODE_I] * 0x80); // Show coin info
+		}
+		else
+		{
+			printf("Invalid Read Port: %d\n", port);
+		}
+
+		return value;
+	}
+
 	uint8_t SDLIoController::Read(uint16_t port, [[maybe_unused]] meen::IController* controller)
 	{
 		auto ret = i8080ArcadeIO_->ReadPort(port);
@@ -237,17 +290,28 @@ namespace i8080_arcade
 		{
 			if (port == 1 || port == 2)
 			{
-				std::promise<uint8_t> p;
-				SDL_Event e{};
-				e.type = siEvent_;
-				e.user.code = EventCode::ReadInput;
-				e.user.data1 = reinterpret_cast<void*>(port);
-				e.user.data2 = reinterpret_cast<void*>(&p);
-				SDL_PushEvent(&e);
-
-				if (quit_ == false)
+				if (runAsync_ == true)
 				{
-					ret = p.get_future().get();
+					// This block isn't ideal as it pushes a request to the main
+					// thread and waits for a result ... I don't think we can
+					// remove this and just perform the else case as I don't think
+					// it is safe to do so with SDL across threads.
+					std::promise<uint8_t> p;
+					SDL_Event e{};
+					e.type = siEvent_;
+					e.user.code = EventCode::ReadInput;
+					e.user.data1 = reinterpret_cast<void*>(port);
+					e.user.data2 = reinterpret_cast<void*>(&p);
+					SDL_PushEvent(&e);
+
+					if (quit_ == false)
+					{
+						ret = p.get_future().get();
+					}
+				}
+				else
+				{
+					ret = ReadInputDevice(port, SDL_GetKeyboardState(nullptr));
 				}
 			}
 		}
@@ -337,22 +401,20 @@ namespace i8080_arcade
 	{
 		SDL_Event e;
 		bool quit = false;
+		bool eventTriggered = false;
 		const auto state = SDL_GetKeyboardState(nullptr);
 
-		if (SDL_WaitEvent(&e))
+		if (runAsync_ == true)
 		{
-			// Scan the keyboard for load and save requests
-			auto setInterrupt = [this](Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState)
-			{
-				if (key ^ lastKey && key)
-				{
-					loadSaveInterrupt_ = isr;
-					loadSaveState_ = loadSaveState;
-				}
+			eventTriggered = SDL_WaitEvent(&e);
+		}
+		else
+		{
+			eventTriggered = SDL_PollEvent(&e);
+		}
 
-				return key;
-			};
-
+		if (eventTriggered == true)
+		{
 			switch (e.type)
 			{
 				case SDL_QUIT:
@@ -374,12 +436,15 @@ namespace i8080_arcade
 								{
 									quit_ = true;
 
-									if (SDL_PollEvent(&e))
+									if (runAsync_ == true)
 									{
-										if (e.type == siEvent_ && e.user.code == EventCode::ReadInput)
+										if (SDL_PollEvent(&e))
 										{
-											static_cast<std::promise<uint8_t>*>(e.user.data2)->set_value(0);
-										}
+											if (e.type == siEvent_ && e.user.code == EventCode::ReadInput)
+											{
+												static_cast<std::promise<uint8_t>*>(e.user.data2)->set_value(0);
+											}
+										}	
 									}
 									break;
 								}
@@ -428,7 +493,7 @@ namespace i8080_arcade
 								SDL_RenderPresent(renderer_);
 
 								// Check to see if the user wants to load a rom
-								lastR_ = setInterrupt(state[SDL_SCANCODE_U], lastR_, meen::ISR::Load, false);
+								lastU_ = SetInterrupt(state[SDL_SCANCODE_U], lastU_, meen::ISR::Load, false);
 								break;
 							}
 							case EventCode::RenderAudio:
@@ -456,42 +521,7 @@ namespace i8080_arcade
 							{
 								uint8_t port = reinterpret_cast<uint64_t>(e.user.data1);
 								auto p = static_cast<std::promise<uint8_t>*>(e.user.data2);
-								uint8_t value = 0;
-
-								// We can only load from a save file or save if a rom is currently running (engine will generate an error otherwise)
-								// so we only allow the user to perform these operations when a rom is running only.
-								// (the ReadInput event is only triggered when a rom is running)
-								lastU_ = setInterrupt(state[SDL_SCANCODE_R], lastR_, meen::ISR::Load, true);
-								lastY_ = setInterrupt(state[SDL_SCANCODE_Y], lastY_, meen::ISR::Save, false);
-
-								if (port == 1)
-								{
-									value = 0x08;
-									value |= (state[SDL_SCANCODE_C] * 0x01); // Credit
-									value |= (state[SDL_SCANCODE_1] * 0x04); // 1P
-									value |= (state[SDL_SCANCODE_2] * 0x02); // 2P
-									value |= (state[SDL_SCANCODE_A] * 0x20); // 1P Left
-									value |= (state[SDL_SCANCODE_S] * 0x10); // 1P Fire
-									value |= (state[SDL_SCANCODE_D] * 0x40); // 1P Right
-								}
-								else if (port == 2)
-								{
-									value |= (state[SDL_SCANCODE_3] * 0x00); // 3 Ships
-									value |= (state[SDL_SCANCODE_4] * 0x01); // 4 Ships
-									value |= (state[SDL_SCANCODE_5] * 0x02); // 5 Ships
-									value |= (state[SDL_SCANCODE_6] * 0x03); // 6 Ships
-									value |= (state[SDL_SCANCODE_T] * 0x04); // Tilt
-									value |= (state[SDL_SCANCODE_E] * 0x08); // Extra Ship at
-									value |= (state[SDL_SCANCODE_J] * 0x20); // 2P Left
-									value |= (state[SDL_SCANCODE_K] * 0x10); // 2P Fire
-									value |= (state[SDL_SCANCODE_L] * 0x40); // 2P Right
-									value |= (state[SDL_SCANCODE_I] * 0x80); // Show coin info
-								}
-								else
-								{
-									printf("Invalid Read Port: %d\n", port);
-								}
-
+								auto value = ReadInputDevice(port, state);
 								p->set_value(value);
 								break;
 							}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -62,9 +62,9 @@ if(value)\
 static i8080_arcade::MemoryController* MakeMemoryController()
 {
 #ifdef ENABLE_MH_RP2040
-	return new i8080_arcade::MemoryController();
+	return new i8080_arcade::MemoryController(3); // 3 - Three frame for triple buffered rendering
 #else
-	return new i8080_arcade::MemoryController(3);
+	return new i8080_arcade::MemoryController();
 #endif
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -61,21 +61,25 @@ if(value)\
 
 static i8080_arcade::MemoryController* MakeMemoryController()
 {
+#ifdef ENABLE_MH_RP2040
 	return new i8080_arcade::MemoryController();
+#else
+	return new i8080_arcade::MemoryController(3);
+#endif
 }
 
-static i8080_arcade::IIoController* MakeIoController(const JsonVariant& audioHardware, const JsonVariant& videoHardware)
+static i8080_arcade::IIoController* MakeIoController(bool runAsync, const JsonVariant& audioHardware, const JsonVariant& videoHardware)
 {
 #ifdef ENABLE_MH_RP2040
-	return new i8080_arcade::RPIoController(audioHardware, videoHardware);
+	return new i8080_arcade::RPIoController(runAsync, audioHardware, videoHardware);
 #else
-	return new i8080_arcade::SDLIoController(audioHardware, videoHardware);
+	return new i8080_arcade::SDLIoController(runAsync, audioHardware, videoHardware);
 #endif // ENABLE_MH_RP2040
 }
 
 int main(int argc, char** argv)
 {
-    JsonDocument json;
+	JsonDocument json;
 #ifdef ENABLE_MH_RP2040
 	stdio_init_all();
 	// Open the configuration file, see the README for an explanation of each configuration option
@@ -83,27 +87,14 @@ int main(int argc, char** argv)
 	auto e = deserializeJson(json, std::string(&rpConfigStart, &rpConfigEnd - &rpConfigStart));
 #else
 	std::ifstream fin;
-
+	auto configFilePath = argc == 1 ? "conf/config.json" : argv[1];
 	// Open the configuration file, see the README for an explanation of each configuration option
-	if (argc == 1)
-	{
-		fin.open("conf/config.json");
-	}
-	else
-	{
-		fin.open(argv[1]);
-	}
-
+	fin.open(configFilePath);
     auto e = deserializeJson(json, fin);
 #endif // ENABLE_MH_RP2040
 	CHECK_ERROR(e, printf("Parse error while deserializing json config file\n"));
 
-	std::string saveFilePath = "save-files";
-
-	if (json["saveFilePath"])
-	{
-		saveFilePath = json["saveFilePath"].as<std::string>();
-	}
+	std::string saveFilePath = json["saveFilePath"] ? json["saveFilePath"].as<std::string>() : "save-files";
 
 	auto hardware = json["i8080Arcade"]["hardware"];
 	CHECK_ERROR(!hardware, printf("Invalid json config file format: hardware section not found\n"));
@@ -111,12 +102,15 @@ int main(int argc, char** argv)
 	auto software = json["i8080Arcade"]["software"];
 	CHECK_ERROR(!software, printf("Invalid json config file format: software section not found\n"));
 
+	auto meen = hardware["meen"];
+	CHECK_ERROR(!meen, printf("Invalid json config file format: meen section not found\n"));
+
 	// Create our custom i8080 arcade machine
 	auto machine = meen::Make8080Machine();
 	CHECK_ERROR(!machine, printf("Failed to create i8080 machine\n"));
 
 	// Create our custom i8080 arcade I/O controller based on a specific configuration.
-	auto ioController = MakeIoController(hardware["audio"], hardware["video"]);
+	auto ioController = MakeIoController(meen["runAsync"], hardware["audio"], hardware["video"]);
 	CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
 
 	// Create our custom i8080 arcade memory controller.
@@ -226,7 +220,7 @@ int main(int argc, char** argv)
 
 	// Set the hardware options
 	std::string meenConfig;
-	serializeJson(hardware["meen"], meenConfig);
+	serializeJson(meen, meenConfig);
 	machine->SetOptions(meenConfig.c_str());
 
 	// Run the machine until the 'q' key is pressed or the window is closed (ie; the machine OnIdle handler returns true)


### PR DESCRIPTION
Add support for running from a single thread. This is purely implemented for demonstration purposes.

- Using `JsonVariantConst` rather than `JsonVariant&` as per the ArduinoJson documentation.
- Pass the `runAsync` option to the io controllers so they can determine whether or not to use blocking versions of certain api methods.
- Minor refactoring and documentation updates.