### PR TITLE
#94 fix: restore rp2040 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The current settings for these options should be sufficient, changing them may h
 
 **NOTE**: the RP IO Controller does not support saving state.
 **NOTE**: running in synchronous mode (`runAsync` = `false`) is supported for demonstration purposes, however, it should be left to `true` for performance reasons.
-**NOTE**: running in synchronous mode (`runAsync` = `false`) requires an increase in the `isrFreq` parameter.
+**NOTE**: running in synchronous mode (`runAsync` = `false`) requires an increase in the `isrFreq` parameter for improved responsiveness (240 recommended).
 
 ##### Video
 
@@ -245,7 +245,7 @@ These settings apply to the various arcade roms that can be loaded.
 These settings affect visual output and can be changed. They apply to all game roms loaded.
 
 `bpp:8` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
-`colour:white` - the forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and a 16 bit custom hex value.<br>
+`colour:white` - The forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and a 16 bit custom hex value.<br>
 `orientation:upright` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
 
 **NOTE**: the RP IO Controller only supports cocktail orientation @ 16bpp.

--- a/docs/README-bin.md
+++ b/docs/README-bin.md
@@ -12,6 +12,9 @@ This emulator has been tested against the following roms (which can be found els
 - Balloon Bomber (This one looks to have issues which go beyond the superficial that require further investigation).
 - Lunar Rescue.
 
+For supported desktop platforms The Simple Direct MediaLayer (SDL) is used to render the output and requires a keyboard for interaction (keyboard controls are documented towards the end of this document).
+For supported embedded platforms an st7789 based lcd screen is required for rendering the output (tested with 320x240) with a minimum of 4 buttons for interaction (button controls are documented towards the end of this document).
+
 ### Running the application
 
 A script is provided in the root directory which will configure the environment and run the i8080 arcade machine.
@@ -20,7 +23,9 @@ A script is provided in the root directory which will configure the environment 
 
 ### Configuration
 
-A configuration file targeting the i8080 arcade hardware is provided in json format. It is designed for flexibility and verbosity. It is divided into two main sections:
+A configuration file targeting the i8080 arcade hardware is provided in json format. It is designed for flexibility and verbosity.
+
+It is divided into two main sections:
 
 #### Hardware
 
@@ -30,29 +35,36 @@ These options should be fixed to the specfied values unless stated otherwise.
 
 The current settings for these options should be sufficient, changing them may have a negative impact on performance.
 
-`clockResolution:1000000000 / 60 / 2` - i8080 arcade hardware runs at 60Hz with 2 interrupts per frame, set the machine clock resolution accordingly.<br>
-`isrFreq:0.9` - We require 4 interrupts, 2 for i8080-arcade and 2 machine level interrupts for loading and saving. Ideally we would lock the interrupt service routine frequency to the clock resolution ("isrFreq":1), however, we need to spare some time for checking for load and save requests, so we bump the isrFreq down by ten percent ("isrFreq":0.9). One could lower it further, this would make it more responsive (0.9 should be good enough). Increasing it above 1 would make it slower and not respond to load/save requests.<br>
+`clockSamplingFreq:120` - i8080 arcade hardware runs at 60Hz with 2 interrupts per frame.<br>
+`isrFreq:132` - We require 4 interrupts, 2 for i8080-arcade and 2 machine level interrupts for loading and saving. Ideally we would lock the interrupt service routine frequency to the clock sampling frequency ("isrFreq":120), however, we need to spare some time for checking for load and save requests, so we bump the isrFreq up by ten percent ("isrFreq":132). One could increase it further (increased host cpu usage), this would make it more responsive (132 should be good enough).<br>
 `loadAsync:true` - Load the machine state asynchronously.<br> 
 `runAsync:true` - Run the machine asynchronously from the io.<br>
 `saveAsync:true` - Save the machine state asynchronously.<br>
+
+**NOTE**: the RP IO Controller does not support saving state.
+**NOTE**: running in synchronous mode (`runAsync` = `false`) is supported for demonstration purposes, however, it should be left to `true` for performance reasons.
+**NOTE**: running in synchronous mode (`runAsync` = `false`) requires an increase in the `isrFreq` parameter for improved responsiveness (240 recommended).
 
 ##### Video
 
 Video hardware options. These options can be changed for the desired output.
 
-`width:224` - The width of the screen.<br>
-`height:256` - The height of the screen.<br>
-`full-screen:false` - Window or full screen display.<br>
+`width:224` - The width of the screen. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
+`height:256` - The height of the screen. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
+`fullScreen:false` - Window or full screen display. (Experimental)<br>
+
+**NOTE**: the RP IO Controller does not support scaling or full-screen, the width and height parameters will be used to center the output on the display device.
 
 ##### Audio
 
 Audio hardware options. The current settings for these options should be sufficient.
 
 `channels:1` - The number of audio output channels.<br>
-`sample-rate:11025` - The audio output sample rate.<br>
-`sample-size:512` - The audio output sample size.<br>
+`sampleRate:11025` - The audio output sample rate.<br>
+`sampleSize:512` - The audio output sample size.<br>
 
 **NOTE**: these options can be changed if using custom audio samples.
+**NOTE**: the RP IO Controller does not support audio, these options have no affect.
 
 #### Software
 
@@ -62,9 +74,11 @@ These settings apply to the various arcade roms that can be loaded.
 
 These settings affect visual output and can be changed. They apply to all game roms loaded.
 
-`bpp:8` - Bits per pixel, supported values are 1 (currently not supported via the SDL IO controller) and 8.<br>
-`colour:white`: the forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and an 8 bit custom hex value.<br>
+`bpp:8` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
+`colour:white` - The forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and a 16 bit custom hex value.<br>
 `orientation:upright` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
+
+**NOTE**: the RP IO Controller only supports cocktail orientation @ 16bpp.
 
 ##### Audio
 
@@ -73,39 +87,57 @@ These settings affect audio output. They can be changed if different audio sampl
 `audio:file` - The name of the audio sample to load (empty entries are ignored and **must** not be removed).<br>
 
 **NOTE**: the position of the audio files in the array **must** not be changed.<br>
-**NOTE**: if changing the audio files, the audio hardware properties may need to be updated (untested).
+**NOTE**: if changing the audio files, the audio hardware properties may need to be updated (untested).<br>
+**NOTE**: the RP IO Controller does not support audio, these setting have no affect.
 
 ##### Space Invaders/Space Invaders Deluxe/Space Invaders II/Balloon Bomber/Lunar Rescue
 
-These settings are fixed to the specified rom and should not be changed.
+These settings are fixed to the specified rom.
 
-`memory:rom:file:name` - The name of the rom file.<br>
-`memory:rom:file:offset` - The start of memory rom load offset.<br>
-`memory:rom:file:size` - The rom file size.<br>
-`memory:ram:block:offset` - The start of memory ram block offset.<br>
-`memory:ram:block:size` - The ram block size.<br>
+`roms:name` - The name of the rom. This is used as the name of the save state json file.<br>
+`roms:cpu:pc` - The meen cpu program counter. It **must** not be changed, doing so will yield undefined behaviour.<br>
+`roms:cpu:sp` - The meen cpu stack pointer. It **must** not be changed, doing so will yield undefined behaviour.<br>
+`memory:rom:scheme` - An optional parameter specifying the type of the rom resource to load, either `file://` or `json://`.<br>
+`memory:rom:directory` - An optional parameter specifying the path to the rom resource to load.<br>
+`memory:rom:[block]:bytes`: The rom resource to load. When the resource is fully qualified it will ignore the scheme and directory parameters.
+`memory:rom:[block]:offset`: The offset into memory where the rom will be loaded, this value **must** not be changed, doing so will yield undefined behaviour.<br>
 
-### Keyboard Controls
+### Desktop Keyboard Controls
 
 `q`: Quit<br>
 `c`: Credit<br>
-`1`, 1P<br>
+`1`: 1P<br>
 `2`: 2P<br>
-`a`: 1P Left<br>
-`s`: 1P Fire<br>
-`d`: 1P Right<br>
-`3`: 3 Ships<br>
-`4`: 4 Ships<br>
-`5`: 5 Ships<br>
-`6`: 6 Ships<br>
+`a`: 1P left<br>
+`s`: 1P fire<br>
+`d`: 1P right<br>
+`3`: 3 ships<br>
+`4`: 4 ships<br>
+`5`: 5 ships<br>
+`6`: 6 ships<br>
 `t`: Tilt<br>
 `e`: Extra ship at<br>
-`j`: 2P Left<br>
-`k`: 2P Fire<br>
-`l`: 2P Right<br>
+`j`: 2P left<br>
+`k`: 2P fire<br>
+`l`: 2P right<br>
 `i`: Show coin info<br>
 `y`: Save game<br>
-`r`: Load game<br> 
+`r`: Load save game<br>
+`u`: Load from rom<br>
+
+### Embedded button controls
+
+Four buttons can be used to control a one player emulation. All game settings will be at defaults, this includes starting with 3 ships with an addtional
+ship every 1500 points.
+
+More buttons and/or logic can be added for a more complete emulation, 2 player support for example (keeping it simple for demonstration purposes).
+
+The pin layout used is the same as the [hardware lcd](https://www.waveshare.com/wiki/Pico-LCD-2) used for testing.
+
+`button 0`: when on the rom attraction screen, select the previous rom in the list of supported roms, when in gameplay mode, move the ship to the left.<br>
+`button 1`: when on the rom attraction screen, add a credit and start a single player game, when in gameplay mode, quit and return to the attraction screen.<br>
+`button 2`: when in gameplay mode, fire at the enemy.<br>
+`button 3`: when on the rom attraction screen, select the next rom in the list of supported roms, when in gameplay mode, move the ship to the right.<br>
 
 ![space-invaders](docs/images/space-invaders.png) ![space-invaders-deluxe](docs/images/space-invaders-deluxe.png) ![lunar-rescue](docs/images/lunar-rescue.png) ![balloon-bomber](docs/images/balloon-bomber.png)
 

--- a/include/i8080_arcade/MemoryController.h
+++ b/include/i8080_arcade/MemoryController.h
@@ -23,6 +23,7 @@ SOFTWARE.
 #ifndef MEMORYCONTROLLER_H
 #define MEMORYCONTROLLER_H
 
+#define ARDUINOJSON_ENABLE_STRING_VIEW 1
 #include <ArduinoJson.h>
 #include <array>
 #include <memory>

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -145,13 +145,13 @@ namespace i8080_arcade
         /** The number of remaining ships
 
             This counter is used to track when to move from gameplay mode to
-            attraction screen mode and vide versa.
+            attraction screen mode and vice versa.
             When it is greater than 0, we are in gameplay mode and buttons 0
             and 3 will be used to move the ship left and right. When it is
             0 we are in attraction screen mode and these buttons will be used
             to select which rom to load.
         */
-        int ships_{};
+        int ships_{ -1 };
 
         /** Button state tracking
 
@@ -184,12 +184,24 @@ namespace i8080_arcade
 
             Define a region in display ram where pixels can be written to.
 
-            @param    startX    the starting x coordinate of the blit region.
-            @param    startY    the starting y coordinate of the blit region.
-            @param    endX      the ending x coordinate of the blit region.
-            @param    endX      the ending x coordinate of the blit region.
+            @param    startX    The starting x coordinate of the blit region.
+            @param    startY    The starting y coordinate of the blit region.
+            @param    endX      The ending x coordinate of the blit region.
+            @param    endX      The ending x coordinate of the blit region.
         */
         static void SetRegion(uint16_t Xstart, uint16_t Ystart, uint16_t Xend, uint16_t Yend);
+
+        /** Single button press
+
+            Returns the state of tthe button (ignoring repeats).
+
+            bool    button        True of the button is currently pressed.
+            bool    lastButton    The prevos state of the button parameter.
+                                  True this is a button repeat, false otherwise.
+
+            return                True for a single press, false otherwise.
+        */
+        bool ButtonPress(bool button, bool& lastButton);
 
     public:
         /** Initialisation constructor

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -140,7 +140,7 @@ namespace i8080_arcade
 
             The pixels that will be rendered to the display.
         */
-        std::unique_ptr<uint8_t> texture_;
+        std::vector<uint8_t> texture_;
 
         /** The number of remaining ships
 
@@ -299,8 +299,8 @@ namespace i8080_arcade
         void HandleError(std::string&& errorMsg) final;
 
         /** Load the selected rom or the save state of the currently selected rom
-			
-        @param    maxSize            The total number of roms in the rom list	
+
+        @param    maxSize            The total number of roms in the rom list
 
         @return                      A tuple holding two values:
                                      bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -21,22 +21,8 @@ SOFTWARE.
 */
 
 #include <algorithm>
-#include <cstring>
 
 #include "i8080_arcade/MemoryController.h"
-
-#ifdef ENABLE_MH_RP2040
-extern uint8_t invadersHStart;
-extern uint8_t invadersHEnd;
-extern uint8_t invadersGStart;
-extern uint8_t invadersGEnd;
-extern uint8_t invadersFStart;
-extern uint8_t invadersFEnd;
-extern uint8_t invadersEStart;
-extern uint8_t invadersEEnd;
-#else
-#include <fstream>
-#endif // ENABLE_MH_RP2040
 
 namespace i8080_arcade
 {
@@ -50,7 +36,7 @@ namespace i8080_arcade
             framePool_.AddResource(new std::array<uint8_t, 7168>);
         }
 
-        memset(memory_.get(), 0x00, memorySize_);
+        std::ranges::fill(memory_.get(), memory_.get() + memorySize_, 0x00);
     }
 
     meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr MemoryController::GetVideoFrame() const
@@ -59,7 +45,7 @@ namespace i8080_arcade
 
         if(frame != nullptr)
         {
-            std::copy_n(memory_.get() + 0x2400, frame->size(), frame->begin());
+            std::ranges::copy_n(memory_.get() + 0x2400, frame->size(), frame->begin());
         }
 
         return frame;

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -261,8 +261,8 @@ namespace i8080_arcade
                 else
                 {
                     // When scrolling roms we DONT want button repeats
-                    //ret |= ButtonPress(!gpio_get(Pin::K0), lastK0_) * 0x20; // 1P Left
-                    //ret |= ButtonPress(!gpio_get(Pin::K3), lastK3_) * 0x40; // 1P Right
+                    ret |= ButtonPress(!gpio_get(Pin::K0), lastK0_) * 0x20;
+                    ret |= ButtonPress(!gpio_get(Pin::K3), lastK3_) * 0x40;
 
                     if (ret & 0x01)
                     {
@@ -271,21 +271,21 @@ namespace i8080_arcade
                         ships_ = 3;
                     }
 
-                    //if (ret & 0x20)
-                    //{
+                    if (ret & 0x20)
+                    {
                         //printf("Move to the previous rom\n");
                         // turn off move left
-                    //    ret &= ~0x20;
+                        ret &= ~0x20;
                         // TODO: We want move to the previous rom, send previous rom event
-                    //}
+                    }
 
-                    //if (ret & 0x40)
-                    //{
+                    if (ret & 0x40)
+                    {
                         //printf("Move to the next rom\n");
                         // turn off move right
-                    //    ret &= ~0x40;
+                        ret &= ~0x40;
                         // TODO: We want move to the next rom, send next rom event
-                    //}
+                    }
                 }
             }
             else if (port == 2)
@@ -329,7 +329,7 @@ namespace i8080_arcade
         {
             case 0:
             {
-                if (ships_ = -1)
+                if (ships_ == -1)
                 {
                     // Check button 2 press to trigger a rom load interrupt
                     if (ButtonPress (!gpio_get(Pin::K2), lastK2_))

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -225,6 +225,19 @@ namespace i8080_arcade
         return std::make_error_code(std::errc::not_supported);
     }
 
+    bool RPIoController::ButtonPress(bool button, bool& lastButton)
+    {
+        bool press = false;
+
+        if ((button ^ lastButton) && button)
+        {
+            press = true;
+        }
+
+        lastButton = button;
+        return press;
+    }
+
     uint8_t RPIoController::Read(uint16_t port, [[maybe_unused]] meen::IController* memoryController)
     {
         uint8_t ret = i8080ArcadeIO_->ReadPort(port);
@@ -233,30 +246,16 @@ namespace i8080_arcade
         {
             if (port == 1)
             {
-                auto buttonPress = [](bool button, bool& lastButton)
-                {
-                    bool press = false;
-
-                    if ((button ^ lastButton) && button)
-                    {
-                        press = true;
-                    }
-
-                    lastButton = button;
-                    return press;
-                };
-
-
                 // Always force single player mode (0x04) (2P mode is not supported)
                 ret = 0x08 | 0x04;
-                ret |= buttonPress(!gpio_get(Pin::K1), lastK1_) * 0x01; // Credit
+                ret |= ButtonPress(!gpio_get(Pin::K1), lastK1_) * 0x01; // Credit
 
                 if (ships_ > 0)
                 {
                     // We want button repeats during gameplay for player movement
                     ret |= !gpio_get(Pin::K0) * 0x20; // 1P Left
                     ret |= !gpio_get(Pin::K3) * 0x40; // 1P Right
-                    ret |= buttonPress(!gpio_get(Pin::K2), lastK2_) * 0x10; // 1P Fire
+                    ret |= ButtonPress(!gpio_get(Pin::K2), lastK2_) * 0x10; // 1P Fire
 
                     if (ret & 0x01)
                     {
@@ -271,8 +270,8 @@ namespace i8080_arcade
                 else
                 {
                     // When scrolling roms we DONT want button repeats
-                    ret |= buttonPress(!gpio_get(Pin::K0), lastK0_) * 0x20; // 1P Left
-                    ret |= buttonPress(!gpio_get(Pin::K3), lastK3_) * 0x40; // 1P Right
+                    //ret |= ButtonPress(!gpio_get(Pin::K0), lastK0_) * 0x20; // 1P Left
+                    //ret |= ButtonPress(!gpio_get(Pin::K3), lastK3_) * 0x40; // 1P Right
 
                     if (ret & 0x01)
                     {
@@ -281,21 +280,21 @@ namespace i8080_arcade
                         ships_ = 3;
                     }
 
-                    if (ret & 0x20)
-                    {
+                    //if (ret & 0x20)
+                    //{
                         //printf("Move to the previous rom\n");
                         // turn off move left
-                        ret &= ~0x20;
+                    //    ret &= ~0x20;
                         // TODO: We want move to the previous rom, send previous rom event
-                    }
+                    //}
 
-                    if (ret & 0x40)
-                    {
+                    //if (ret & 0x40)
+                    //{
                         //printf("Move to the next rom\n");
                         // turn off move right
-                        ret &= ~0x40;
+                    //    ret &= ~0x40;
                         // TODO: We want move to the next rom, send next rom event
-                    }
+                    //}
                 }
             }
             else if (port == 2)
@@ -340,6 +339,16 @@ namespace i8080_arcade
         {
             case 0:
             {
+                if (ships_ = -1)
+                {
+                    // Check button 2 press to trigger a rom load interrupt
+                    if (ButtonPress (!gpio_get(Pin::K2), lastK2_))
+                    {
+                        printf("Load Interrupt\n");
+                        isr = meen::ISR::Load;
+                        ships_ = 0;
+                    }
+                }
                 break;
             }
             case 1:

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -51,16 +51,14 @@ namespace i8080_arcade
         widthOffset_ = (width_ - i8080ArcadeIO_->GetVRAMWidth()) / 2;
         heightOffset_ = (height_ - i8080ArcadeIO_->GetVRAMHeight()) / 2;
 
-        queue_init(&videoFrameQueue_, sizeof(int), 2);
-        queue_init(&freeQueue_, sizeof(int), 2);
+        queue_init(&videoFrameQueue_, sizeof(uintptr_t), 2);
+        queue_init(&freeQueue_, sizeof(uintptr_t), 2);
 
         for(int i = 0; i < 2; i++)
         {
-            int p = std::bit_cast<int>(&videoFrameWrapper_[i]);
+            auto p = std::bit_cast<uintptr_t>(&videoFrameWrapper_[i]);
             queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
         }
-
-        static_assert(sizeof(VideoFrameWrapper*) == sizeof(int));
 
         stdio_init_all();
         spi_init(spi1, 62.5 * 1000000);
@@ -208,15 +206,8 @@ namespace i8080_arcade
         }
 
         i8080ArcadeIO_->SetOptions(meenConfig.c_str());
-
         // We decompress and write one scanline at a time to lcd ram
-        texture_ = std::make_unique<uint8_t>((i8080ArcadeIO_->GetVRAMWidth() * bpp) / 8); // 8 - bits per pixel
-
-        if (texture_ == nullptr)
-        {
-            return std::make_error_code (std::errc::not_enough_memory);
-        }
-
+        texture_.resize((i8080ArcadeIO_->GetVRAMWidth() * bpp) / 8); // 8 - bits per pixel
         return std::error_code{};
     }
 
@@ -332,7 +323,6 @@ namespace i8080_arcade
     meen::ISR RPIoController::ServiceInterrupts(uint64_t currTime, uint64_t cycles, meen::IController* memoryController)
     {
         auto isr = meen::ISR::NoInterrupt;
-
         auto interrupt = i8080ArcadeIO_->GenerateInterrupt(currTime, cycles);
 
         switch(interrupt)
@@ -344,7 +334,6 @@ namespace i8080_arcade
                     // Check button 2 press to trigger a rom load interrupt
                     if (ButtonPress (!gpio_get(Pin::K2), lastK2_))
                     {
-                        printf("Load Interrupt\n");
                         isr = meen::ISR::Load;
                         ships_ = 0;
                     }
@@ -367,7 +356,7 @@ namespace i8080_arcade
 
                     if(vfw->videoFrame != nullptr)
                     {
-                        int p = std::bit_cast<int>(vfw);
+                        auto p = std::bit_cast<uintptr_t>(vfw);
                         success = queue_try_add(&videoFrameQueue_, static_cast<void*>(&p));
 
                         if(success == false)
@@ -440,10 +429,6 @@ namespace i8080_arcade
 
     bool RPIoController::HandleEvent()
     {
-        auto arcadeWidth = i8080ArcadeIO_->GetVRAMWidth();
-        auto arcadeHeight = i8080ArcadeIO_->GetVRAMHeight();
-        auto compressedWidth = arcadeWidth >> 3;
-        auto dst = std::bit_cast<uint16_t*>(texture_.get());
         VideoFrameWrapper* vfw = nullptr;
 
         if (runAsync_ == true)
@@ -461,11 +446,17 @@ namespace i8080_arcade
         auto videoFrame = std::move(vfw->videoFrame);
         // explicitly set to nullptr as there is no requirement on std::move to do this
         vfw->videoFrame = nullptr;
-        auto p = std::bit_cast<int>(vfw);
+        auto p = std::bit_cast<uintptr_t>(vfw);
         queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
 
         if (videoFrame != nullptr)
         {
+            auto arcadeWidth = i8080ArcadeIO_->GetVRAMWidth();
+            auto arcadeHeight = i8080ArcadeIO_->GetVRAMHeight();
+            auto compressedWidth = arcadeWidth >> 3;
+            auto dst = texture_.data();
+            auto dstSize = texture_.size();
+            auto dst16 = std::bit_cast<uint16_t*>(dst);
             auto vf = videoFrame.get()->data();
             uint8_t* bb = nullptr;
 
@@ -508,22 +499,22 @@ namespace i8080_arcade
                         }
 
                         // Blit and render the current scanline
-                        i8080ArcadeIO_->BlitVRAM(std::span(texture_.get(), 512), 512, std::span(vf, compressedWidth));
-                        spi_write16_blocking(spi1, dst, arcadeWidth);
+                        i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), dstSize, std::span(vf, compressedWidth));
+                        spi_write16_blocking(spi1, dst16, arcadeWidth);
 
                         // Update the last scanline index
                         //lastScanline = i;
                     }
-//                      else
-//                          this scanline is the same as its counterpart in the previous frame, no need to render this scanline
+//                  else
+//                      this scanline is the same as its counterpart in the previous frame, no need to render this scanline
 
                     // Move to the next scanline in the back buffer
                     bb += compressedWidth;
                 }
                 else
                 {
-                    i8080ArcadeIO_->BlitVRAM(std::span(texture_.get(), 512), 512, std::span(vf, compressedWidth));
-                    spi_write16_blocking(spi1, dst, arcadeWidth);
+                    i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), dstSize, std::span(vf, compressedWidth));
+                    spi_write16_blocking(spi1, dst16, arcadeWidth);
                 }
 
                 // Move to the next scanline in the front buffer

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -98,26 +98,31 @@ int main(int argc, char** argv)
 	auto machine = meen::Make8080Machine();
 	CHECK_ERROR(!machine, printf("Failed to create i8080 machine\n"));
 
-	// Configure everything in a block so that all locals are destroyed upon block exit 
+	// Configure everything in a block so that all locals are destroyed upon block exit
 	{
 		JsonDocument json;
-	#ifdef ENABLE_MH_RP2040
-		const std::unordered_map<std::string_view, uintptr_t> romNameToAddr
+#ifdef ENABLE_MH_RP2040
+		auto toPair = [](uint8_t* s, uint8_t* e)
 		{
-			{ "invaders-e.bin", std::bit_cast<uintptr_t>(&invadersEStart) }, { "invaders-f.bin", std::bit_cast<uintptr_t>(&invadersFStart) }, { "invaders-g.bin", std::bit_cast<uintptr_t>(&invadersGStart) }, { "invaders-h.bin", std::bit_cast<uintptr_t>(&invadersHStart) }
+			return std::pair<uintptr_t, uintptr_t>(std::bit_cast<uintptr_t>(s), e - s);
+		};
+
+		const std::unordered_map<std::string_view, std::pair<uintptr_t, uint16_t>> romNameToAddr
+		{
+			{ "invaders-e.bin", toPair(&invadersEStart, &invadersEEnd) }, { "invaders-f.bin", toPair(&invadersFStart, &invadersFEnd) }, { "invaders-g.bin", toPair(&invadersGStart, &invadersGEnd) }, { "invaders-h.bin", toPair(&invadersHStart, &invadersHEnd) }
 		};
 
 		stdio_init_all();
 		// Open the configuration file, see the README for an explanation of each configuration option
 		//cppcheck-suppress comparePointers
 		auto e = deserializeJson(json, std::string_view(&rpConfigStart, &rpConfigEnd - &rpConfigStart));
-	#else
+#else
 		std::ifstream fin;
 		auto configFilePath = argc == 1 ? "conf/config.json" : argv[1];
 		// Open the configuration file, see the README for an explanation of each configuration option
 		fin.open(configFilePath);
 		auto e = deserializeJson(json, fin);
-	#endif // ENABLE_MH_RP2040
+#endif // ENABLE_MH_RP2040
 		CHECK_ERROR(e, printf("Parse error while deserializing json config file\n"));
 
 		saveFilePath = json["saveFilePath"] ? json["saveFilePath"].as<std::string>() : "save-files";
@@ -134,8 +139,8 @@ int main(int argc, char** argv)
 			CHECK_ERROR(!r["memory"]["rom"], printf("No rom found in config file memory\n"));
 			CHECK_ERROR(!r["memory"]["rom"]["block"], printf("No rom block found in config file memory\n"));
 
-	// For baremetal platforms we need to update the config file so it loads from flash rather than a file
-	#ifdef ENABLE_MH_RP2040
+// For baremetal platforms we need to update the config file so it loads from flash rather than a file
+#ifdef ENABLE_MH_RP2040
 			auto&& rom = r["memory"]["rom"];
 			// Update the scheme
 			rom["scheme"] = "mem://";
@@ -145,10 +150,10 @@ int main(int argc, char** argv)
 				// Check the names of the roms and set the correct rom address accordingly
 				auto name = block["bytes"].as<std::string_view>();
 				CHECK_ERROR(!romNameToAddr.contains(name), printf("The memory rom block is missing bytes: %s\n", std::string(name).c_str()));
-				block["bytes"] = std::to_string(romNameToAddr.at(name));
+				block["bytes"] = std::to_string(romNameToAddr.at(name).first);
+				block["size"] = romNameToAddr.at(name).second;
 			}
-	#endif // ENABLE_MH_RP2040
-
+#endif // ENABLE_MH_RP2040
 			// Cache all rom strings in a vector of pairs with first being the rom name
 			// and the second being the rom config json.
 			std::string str;
@@ -211,7 +216,7 @@ int main(int argc, char** argv)
 
 		// Will be called from a different thread if the 'runAsync' or 'saveAsync' options are set to true.
 		// This is a simple implementation which will overwrite the previous save file
-	#ifndef ENABLE_MH_RP2040
+#ifndef ENABLE_MH_RP2040
 		machine->OnSave([&jsonRoms, &saveFilePath](const char* json, meen::IController* ioController)
 		{
 			std::error_code ec;
@@ -233,7 +238,7 @@ int main(int argc, char** argv)
 			fout.write(json, strlen(json));
 			return meen::errc::no_error;
 		});
-	#endif // ENABLE_MH_RP2040
+#endif // ENABLE_MH_RP2040
 		// Will be called from a different thread if the 'runAsync' or 'loadAsync' configuration options are set to true
 		machine->OnLoad([&jsonRoms, &saveFilePath](char* json, int* jsonLen, meen::IController* ioController)
 		{
@@ -241,15 +246,15 @@ int main(int argc, char** argv)
 
 			if (loadSaveState == true)
 			{
-	#ifdef ENABLE_MH_RP2040
+#ifdef ENABLE_MH_RP2040
 				return meen::errc::not_implemented;
-	#else
+#else
 				// The engine will generate a parse error if a truncation occurs, however, if one wanted to
 				// check for that here they could by storing the return value in a different variable and then
 				// compare that value to *jsonLen. When that variable is greater than or equal to *jsonLen then
 				// a truncation has occurred.
 				*jsonLen = snprintf(json, *jsonLen, "file://%s/%s.json", saveFilePath.c_str(), jsonRoms[romIndex].first.c_str());
-	#endif // ENABLE_MH_RP2040
+#endif // ENABLE_MH_RP2040
 			}
 			else
 			{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <vector>
+
 #include "meen/MachineFactory.h"
 #include "meen/Error.h"
 #include "i8080_arcade/MemoryController.h"
@@ -38,6 +40,15 @@ while(value)\
 #include <pico/stdlib.h>
 
 #include "i8080_arcade/RPIoController.h"
+
+extern uint8_t invadersHStart;
+extern uint8_t invadersHEnd;
+extern uint8_t invadersGStart;
+extern uint8_t invadersGEnd;
+extern uint8_t invadersFStart;
+extern uint8_t invadersFEnd;
+extern uint8_t invadersEStart;
+extern uint8_t invadersEEnd;
 
 extern char rpConfigStart;
 extern char rpConfigEnd;
@@ -79,149 +90,202 @@ static i8080_arcade::IIoController* MakeIoController(bool runAsync, const JsonVa
 
 int main(int argc, char** argv)
 {
-	JsonDocument json;
-#ifdef ENABLE_MH_RP2040
-	stdio_init_all();
-	// Open the configuration file, see the README for an explanation of each configuration option
-	//cppcheck-suppress comparePointers
-	auto e = deserializeJson(json, std::string(&rpConfigStart, &rpConfigEnd - &rpConfigStart));
-#else
-	std::ifstream fin;
-	auto configFilePath = argc == 1 ? "conf/config.json" : argv[1];
-	// Open the configuration file, see the README for an explanation of each configuration option
-	fin.open(configFilePath);
-    auto e = deserializeJson(json, fin);
-#endif // ENABLE_MH_RP2040
-	CHECK_ERROR(e, printf("Parse error while deserializing json config file\n"));
-
-	std::string saveFilePath = json["saveFilePath"] ? json["saveFilePath"].as<std::string>() : "save-files";
-
-	auto hardware = json["i8080Arcade"]["hardware"];
-	CHECK_ERROR(!hardware, printf("Invalid json config file format: hardware section not found\n"));
-
-	auto software = json["i8080Arcade"]["software"];
-	CHECK_ERROR(!software, printf("Invalid json config file format: software section not found\n"));
-
-	auto meen = hardware["meen"];
-	CHECK_ERROR(!meen, printf("Invalid json config file format: meen section not found\n"));
-
+	// Store the required json needed to load a specific rom (first is the rom name, second is the rom config json)
+	std::vector<std::pair<std::string, std::string>> jsonRoms;
+	// The path where our save files will reside (not applicable for embedded targets)
+	std::string saveFilePath;
 	// Create our custom i8080 arcade machine
 	auto machine = meen::Make8080Machine();
 	CHECK_ERROR(!machine, printf("Failed to create i8080 machine\n"));
 
-	// Create our custom i8080 arcade I/O controller based on a specific configuration.
-	auto ioController = MakeIoController(meen["runAsync"], hardware["audio"], hardware["video"]);
-	CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
-
-	// Create our custom i8080 arcade memory controller.
-	auto memoryController = MakeMemoryController();
-	CHECK_ERROR(!memoryController, printf("Failed to create the memory controller\n"));
-	
-	// Set up the custom controllers prior to configuring the machine.
-
-	auto err = ioController->LoadVideoTextures(software["video"]);
-	CHECK_ERROR(err, printf("Failed to load video textures: %s\n", err.message().c_str()));
-
-	err = ioController->LoadAudioSamples(software["audio"]);
-	CHECK_ERROR((err && err.value() != static_cast<int>(std::errc::not_supported)), printf("Failed to load audio samples: %s\n", err.message().c_str()));
-
-	// Configure the machine.
-
-	// Log any error messages generated, do this as early as possible for best meen error coverage
-	err = machine->OnError([](std::error_code ec, const char* fileName, const char* functionName, uint32_t line, uint32_t column, meen::IController* ioController)
+	// Configure everything in a block so that all locals are destroyed upon block exit 
 	{
-		auto len = snprintf(nullptr, 0, "file: %s(%u:%u) `%s`: %s\n", fileName, line, column, functionName, ec.message().c_str());
-		std::string errorMsg(len, '\0');
-		len = snprintf(errorMsg.data(), len, "file: %s(%u:%u) `%s`: %s\n", fileName, line, column, functionName, ec.message().c_str());
-		
-		// It's possible for this to be nullptr if the io controller has been removed (should not happen in this demo,
-		// but we perform the check for correctness and print a warning message).
-		if (ioController != nullptr)
+		JsonDocument json;
+	#ifdef ENABLE_MH_RP2040
+		const std::unordered_map<std::string_view, uintptr_t> romNameToAddr
 		{
-			// We only pass around one type of controller, so this cast is safe.
-			static_cast<i8080_arcade::IIoController*>(ioController)->HandleError(std::move(errorMsg));
-		}
-		else
+			{ "invaders-e.bin", std::bit_cast<uintptr_t>(&invadersEStart) }, { "invaders-f.bin", std::bit_cast<uintptr_t>(&invadersFStart) }, { "invaders-g.bin", std::bit_cast<uintptr_t>(&invadersGStart) }, { "invaders-h.bin", std::bit_cast<uintptr_t>(&invadersHStart) }
+		};
+
+		stdio_init_all();
+		// Open the configuration file, see the README for an explanation of each configuration option
+		//cppcheck-suppress comparePointers
+		auto e = deserializeJson(json, std::string_view(&rpConfigStart, &rpConfigEnd - &rpConfigStart));
+	#else
+		std::ifstream fin;
+		auto configFilePath = argc == 1 ? "conf/config.json" : argv[1];
+		// Open the configuration file, see the README for an explanation of each configuration option
+		fin.open(configFilePath);
+		auto e = deserializeJson(json, fin);
+	#endif // ENABLE_MH_RP2040
+		CHECK_ERROR(e, printf("Parse error while deserializing json config file\n"));
+
+		saveFilePath = json["saveFilePath"] ? json["saveFilePath"].as<std::string>() : "save-files";
+
+		auto hardware = json["i8080Arcade"]["hardware"];
+		CHECK_ERROR(!hardware, printf("Invalid json config file format: hardware section not found\n"));
+
+		auto software = json["i8080Arcade"]["software"];
+		CHECK_ERROR(!software, printf("Invalid json config file format: software section not found\n"));
+
+		for(auto&& r : software["roms"].as<JsonArray>())
 		{
-			printf ("Warning: no io controller attached, error: %s", errorMsg.c_str());
-		}
-	});
-	// Need to manually check the error here as the method could fail before the handler is registered
-	CHECK_ERROR(err, printf("Failed to set the OnError handler: %s\n", err.message().c_str()));
-	
-	// Beyond this point, all meen generated errors will be picked up by our error handler
+			CHECK_ERROR(!r["memory"], printf("No memory found in config file rom\n"));
+			CHECK_ERROR(!r["memory"]["rom"], printf("No rom found in config file memory\n"));
+			CHECK_ERROR(!r["memory"]["rom"]["block"], printf("No rom block found in config file memory\n"));
 
-	// Load our controllers into the machine - do this immediately after the OnError handler has been registered
-	// so the io controller will be available in the OnError handler.
-	machine->AttachIoController(meen::IControllerPtr(std::move(ioController)));
-	machine->AttachMemoryController(meen::IControllerPtr(std::move(memoryController)));	
+	// For baremetal platforms we need to update the config file so it loads from flash rather than a file
+	#ifdef ENABLE_MH_RP2040
+			auto&& rom = r["memory"]["rom"];
+			// Update the scheme
+			rom["scheme"] = "mem://";
 
-	// Will be called from a different thread if the 'runAsync' or 'saveAsync' options are set to true.
-	// This is a simple implementation which will overwrite the previous save file
-	machine->OnSave([roms = software["roms"], &saveFilePath](const char* json, meen::IController* ioController)
-	{
-#ifdef ENABLE_MH_RP2040
-		return meen::errc::not_implemented;
-#else
-		std::error_code ec;
-		std::filesystem::create_directory(saveFilePath, ec);
+			for (auto&& block : rom["block"].as<JsonArray>())
+			{
+				// Check the names of the roms and set the correct rom address accordingly
+				auto name = block["bytes"].as<std::string_view>();
+				CHECK_ERROR(!romNameToAddr.contains(name), printf("The memory rom block is missing bytes: %s\n", std::string(name).c_str()));
+				block["bytes"] = std::to_string(romNameToAddr.at(name));
+			}
+	#endif // ENABLE_MH_RP2040
 
-		if (ec)
-		{
-			return meen::errc::invalid_argument;
-		}
+			// Cache all rom strings in a vector of pairs with first being the rom name
+			// and the second being the rom config json.
+			std::string str;
+			serializeJson(r, str);
+			jsonRoms.emplace_back (r["name"].as<std::string>(), std::move(str));
 
-		auto [unused, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex(roms.size());
-		auto rom = roms.as<JsonArrayConst>()[romIndex];
-
-		std::ofstream fout(saveFilePath + "/" + rom["name"].as<std::string>() + ".json", std::ios::trunc);
-
-		if (!fout.good())
-		{
-			return meen::errc::invalid_argument;
-		}
-
-		fout.write(json, strlen(json));
-		return meen::errc::no_error;
-#endif
-	});
-
-	// Will be called from a different thread if the 'runAsync' or 'loadAsync' configuration options are set to true
-	machine->OnLoad([roms = software["roms"], &saveFilePath](char* json, int* jsonLen, meen::IController* ioController)
-	{
-		auto [loadSaveState, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex(roms.size());
-		auto rom = roms.as<JsonArrayConst>()[romIndex];
-
-		if (loadSaveState == true)
-		{
-			// The engine will generate a parse error if a truncation occurs, however, if one wanted to
-			// check for that here they could by storing the return value in a different variable and then
-			// compare that value to *jsonLen. When that variable is greater than or equal to *jsonLen then
-			// a truncation has occurred.
-			*jsonLen = snprintf(json, *jsonLen, "file://%s/%s.json", saveFilePath.c_str(), rom["name"].as<std::string>().c_str());
-		}
-		else
-		{
-			// The engine will generate a parse error if a truncation occurs, however, if one wanted to
-			// check for that here they could by comparing the return value (the number of bytes written
-			// excluding the null terminator) against the capacity (*jsonLen). When the return value is
-			// equal to *jsonLen then a truncation has occurred.
-			*jsonLen = serializeJson(rom, json, *jsonLen);
+			// remove this once support for all other roms has been added
+			break;
 		}
 
-		return meen::errc::no_error;
-	});
+		auto meen = hardware["meen"];
+		CHECK_ERROR(!meen, printf("Invalid json config file format: meen section not found\n"));
 
-	// Will always be called from the same thread from which IMachine::Run was called (in this case, the main thread)
-	machine->OnIdle([](meen::IController* ioController)
-	{
-		return static_cast<i8080_arcade::IIoController*>(ioController)->HandleEvent();
-	});
+		// Create our custom i8080 arcade I/O controller based on a specific configuration.
+		auto ioController = MakeIoController(meen["runAsync"], hardware["audio"], hardware["video"]);
+		CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
 
-	// Set the hardware options
-	std::string meenConfig;
-	serializeJson(meen, meenConfig);
-	machine->SetOptions(meenConfig.c_str());
+		// Create our custom i8080 arcade memory controller.
+		auto memoryController = MakeMemoryController();
+		CHECK_ERROR(!memoryController, printf("Failed to create the memory controller\n"));
+
+		// Set up the custom controllers prior to configuring the machine.
+
+		auto err = ioController->LoadVideoTextures(software["video"]);
+		CHECK_ERROR(err, printf("Failed to load video textures: %s\n", err.message().c_str()));
+
+		err = ioController->LoadAudioSamples(software["audio"]);
+		CHECK_ERROR((err && err.value() != static_cast<int>(std::errc::not_supported)), printf("Failed to load audio samples: %s\n", err.message().c_str()));
+
+		// Configure the machine.
+
+		// Log any error messages generated, do this as early as possible for best meen error coverage
+		err = machine->OnError([](std::error_code ec, const char* fileName, const char* functionName, uint32_t line, uint32_t column, meen::IController* ioController)
+		{
+			auto len = snprintf(nullptr, 0, "file: %s(%u:%u) `%s`: %s\n", fileName, line, column, functionName, ec.message().c_str());
+			std::string errorMsg(len, '\0');
+			len = snprintf(errorMsg.data(), len, "file: %s(%u:%u) `%s`: %s\n", fileName, line, column, functionName, ec.message().c_str());
+
+			// It's possible for this to be nullptr if the io controller has been removed (should not happen in this demo,
+			// but we perform the check for correctness and print a warning message).
+			if (ioController != nullptr)
+			{
+				// We only pass around one type of controller, so this cast is safe.
+				static_cast<i8080_arcade::IIoController*>(ioController)->HandleError(std::move(errorMsg));
+			}
+			else
+			{
+				printf ("Warning: no io controller attached, error: %s", errorMsg.c_str());
+			}
+		});
+		// Need to manually check the error here as the method could fail before the handler is registered
+		CHECK_ERROR(err, printf("Failed to set the OnError handler: %s\n", err.message().c_str()));
+
+		// Beyond this point, all meen generated errors will be picked up by our error handler
+
+		// Load our controllers into the machine - do this immediately after the OnError handler has been registered
+		// so the io controller will be available in the OnError handler.
+		machine->AttachIoController(meen::IControllerPtr(std::move(ioController)));
+		machine->AttachMemoryController(meen::IControllerPtr(std::move(memoryController)));
+
+		// Will be called from a different thread if the 'runAsync' or 'saveAsync' options are set to true.
+		// This is a simple implementation which will overwrite the previous save file
+	#ifndef ENABLE_MH_RP2040
+		machine->OnSave([&jsonRoms, &saveFilePath](const char* json, meen::IController* ioController)
+		{
+			std::error_code ec;
+			std::filesystem::create_directory(saveFilePath, ec);
+
+			if (ec)
+			{
+				return meen::errc::invalid_argument;
+			}
+
+			auto [unused, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex(jsonRoms.size());
+			std::ofstream fout(saveFilePath + "/" + jsonRoms[romIndex].first + ".json", std::ios::trunc);
+
+			if (!fout.good())
+			{
+				return meen::errc::invalid_argument;
+			}
+
+			fout.write(json, strlen(json));
+			return meen::errc::no_error;
+		});
+	#endif // ENABLE_MH_RP2040
+		// Will be called from a different thread if the 'runAsync' or 'loadAsync' configuration options are set to true
+		machine->OnLoad([&jsonRoms, &saveFilePath](char* json, int* jsonLen, meen::IController* ioController)
+		{
+			auto [loadSaveState, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex(jsonRoms.size());
+
+			if (loadSaveState == true)
+			{
+	#ifdef ENABLE_MH_RP2040
+				return meen::errc::not_implemented;
+	#else
+				// The engine will generate a parse error if a truncation occurs, however, if one wanted to
+				// check for that here they could by storing the return value in a different variable and then
+				// compare that value to *jsonLen. When that variable is greater than or equal to *jsonLen then
+				// a truncation has occurred.
+				*jsonLen = snprintf(json, *jsonLen, "file://%s/%s.json", saveFilePath.c_str(), jsonRoms[romIndex].first.c_str());
+	#endif // ENABLE_MH_RP2040
+			}
+			else
+			{
+				// The engine will generate a parse error if a truncation occurs, however, if one wanted to
+				// check for that here they could by comparing the return value (the number of bytes written
+				// excluding the null terminator) against the capacity (*jsonLen). When the return value is
+				// equal to *jsonLen then a truncation has occurred.
+				if (jsonRoms[romIndex].second.length() < *jsonLen)
+				{
+					*jsonLen = jsonRoms[romIndex].second.length();
+				}
+				else
+				{
+					printf("TRUNCATED ROM!\n");
+					// should return an error here, whilst is ok not to, it can produce ub depending on what got written
+				}
+
+				std::ranges::copy_n(jsonRoms[romIndex].second.data(), *jsonLen, json);
+
+				// todo: return the number of bytes loaded
+			}
+
+			return meen::errc::no_error;
+		});
+
+		// Will always be called from the same thread from which IMachine::Run was called (in this case, the main thread)
+		machine->OnIdle([](meen::IController* ioController)
+		{
+			return static_cast<i8080_arcade::IIoController*>(ioController)->HandleEvent();
+		});
+
+		// Set the hardware options
+		std::string meenConfig;
+		serializeJson(meen, meenConfig);
+		machine->SetOptions(meenConfig.c_str());
+	}
 
 	// Run the machine until the 'q' key is pressed or the window is closed (ie; the machine OnIdle handler returns true)
 	auto ex = machine->Run();


### PR DESCRIPTION
- Documentation updates
- Changed rp2040 texture scanline memory to `std::vector` rather than using `std::unique_ptr`
- Added ButtonPress method to the RPIoController so it can be checked in its service interrupts method and generate a load interrupt when button 2 is pressed.
- Moved all `main.cpp` set up code into its own block so any unused memory can be reclaimed upon block exit. 