### PR TITLE
#98 feat: rom select screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added single threaded support (`runAsync`,
   `loadAsync` and `saveAsync` options can
   be false) for demonstration purposes.
+* Added a rom selection screen.
 
 0.6.1 [04/08/24]
 * Added profiles for improved build support.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ### Introduction
 
-This demo project shows how to make use of the [meen](http://github.com/nbeddows/meen/) and [meen_hw](http://github.com/nbeddows/meen-hw) packages to emulate an arcade machine, in this case, one based on the Space Invaders Taito/Midway arcade hardware. I don't consider the emulation to be the most efficient, accurate, or to be extensively tested, but I'm happy with where it is at.
+This demo project shows how to make use of the [meen](http://github.com/nbeddows/meen/) and [meen_hw](http://github.com/nbeddows/meen-hw) packages to emulate an arcade machine, in this case, one based on the Space Invaders Taito/Midway arcade hardware.
+
+It adds the following addtional graphical components to the emulation:
+- a rom selection screen allowing the user to use the up and down arrow keys followed by the enter key to load a supported rom (defined in the config file).  
 
 This project has been tested against the following roms (which can be found elsewhere online) with loading/saving game play state on the following platforms: Windows/Linux(x86_64), Linux(armv7hf, armv8), Pico RP2040(armv6-m):
 
@@ -11,6 +14,8 @@ This project has been tested against the following roms (which can be found else
 
 For supported desktop platforms The Simple Direct MediaLayer (SDL) is used to render the output and requires a keyboard for interaction (keyboard controls are documented towards the end of this document).
 For supported embedded platforms an st7789 based lcd screen is requried for rendering the output (tested with 320x240) with a minimum of 4 buttons for interaction (button controls are documented towards the end of this document).
+
+I don't consider the emulation to be the most efficient, accurate, or to be extensively tested, but I'm happy with where it is at.
 
 ### Compilation
 
@@ -219,8 +224,8 @@ The current settings for these options should be sufficient, changing them may h
 
 Video hardware options. These options can be changed for the desired output.
 
-`width:224` - The width of the screen. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
-`height:256` - The height of the screen. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
+`width:224` - The width of the screen in pixels. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
+`height:256` - The height of the screen in pixels. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
 `fullScreen:false` - Window or full screen display. (Experimental)<br>
 
 **NOTE**: the RP IO Controller does not support scaling or full-screen, the width and height parameters will be used to center the output on the display device.
@@ -294,6 +299,7 @@ These settings are fixed to the specified rom.
 `y`: Save game<br>
 `r`: Load save game<br>
 `u`: Load from rom<br>
+`esc`: Return to the rom selection screen<br> 
 
 ### Embedded button controls
 

--- a/docs/README-bin.md
+++ b/docs/README-bin.md
@@ -3,7 +3,8 @@
 
 This is a binary distribution of an [emulated i8080 arcade machine](https://github.com/nbeddows/i8080-arcade) based on the Space Invaders Taito/Midway arcade hardware using [meen](http://github.com/nbeddows/mach-emu/) and [meen-hw](http://github.com/nbeddows/meen-hw/).
 
-I don't consider the emulation to be the most efficient, accurate or to be extensively tested, but I'm happy with where it is at.
+It adds the following addtional graphical components to the emulation:
+- a rom selection screen allowing the user to use the up and down arrow keys followed by the enter key to load a supported rom (defined in the config file).  
 
 This emulator has been tested against the following roms (which can be found elsewhere online):
 
@@ -14,6 +15,8 @@ This emulator has been tested against the following roms (which can be found els
 
 For supported desktop platforms The Simple Direct MediaLayer (SDL) is used to render the output and requires a keyboard for interaction (keyboard controls are documented towards the end of this document).
 For supported embedded platforms an st7789 based lcd screen is required for rendering the output (tested with 320x240) with a minimum of 4 buttons for interaction (button controls are documented towards the end of this document).
+
+I don't consider the emulation to be the most efficient, accurate or to be extensively tested, but I'm happy with where it is at.
 
 ### Running the application
 
@@ -124,6 +127,7 @@ These settings are fixed to the specified rom.
 `y`: Save game<br>
 `r`: Load save game<br>
 `u`: Load from rom<br>
+`esc`: Return to the rom selection screen<br> 
 
 ### Embedded button controls
 

--- a/include/i8080_arcade/IIoController.h
+++ b/include/i8080_arcade/IIoController.h
@@ -33,6 +33,19 @@ namespace i8080_arcade
 {
     struct IIoController : public meen::IController
     {
+		/** Game play screens
+
+			The phases of the i8080 arcade emulator.
+
+			@remark			Addtional screens to add could include Highscore for example.
+			@remark			The i8080 arcade emulator starts on the RomSelect screen, its position should not be changed.
+		*/
+		enum Screen
+		{
+			RomSelect,		/**< The rom select screen where the user can select a rom to load. */
+			Gameplay		/**< The emulated game play for the selected rom that was loaded in the rom select screen. */
+		};
+
         /**	Event handler
 
 			Process all incoming events.
@@ -68,10 +81,12 @@ namespace i8080_arcade
 			Create the video texture that will be rendered to the screen.
 
 			@param	videoTextures	JSON object describing the video texture.
+			@param	frameWidth		The width in pixels of the memory controller video frame.
+			@param	frameHeight		The height in pixels of the memory controller video frame.
 
 			@return					An error in the form of a std::error_code.
 		*/
-		virtual std::error_code LoadVideoTextures(const JsonVariantConst videoTextures) = 0;
+		virtual std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int frameWidth, int frameHeight) = 0;
 
 		/** Load the selected rom or the save state of the currently selected rom
 			

--- a/include/i8080_arcade/MemoryController.h
+++ b/include/i8080_arcade/MemoryController.h
@@ -23,11 +23,9 @@ SOFTWARE.
 #ifndef MEMORYCONTROLLER_H
 #define MEMORYCONTROLLER_H
 
-#define ARDUINOJSON_ENABLE_STRING_VIEW 1
-#include <ArduinoJson.h>
-#include <array>
-#include <memory>
+#include <vector>
 
+#include "i8080_arcade/GlyphRenderer.h"
 #include "meen/Base.h"
 #include "meen/IController.h"
 #include "meen_hw/MH_ResourcePool.h"
@@ -36,45 +34,56 @@ namespace i8080_arcade
 {
     /** Custom memory controller.
 
-        A custom memory controller targetting Space Invaders arcade hardware compatible ROMs
-        based on the st7789vw driver targetting the rp2040 microcontroller.
+        A custom memory controller targetting Space Invaders arcade hardware compatible ROMs.
+
+        The emulated hardware runs on an Intel8080 with 64k of memory therefore the memory
+        controller's internal memory size will be set to this. A subsection of this memory
+        houses the video ram which is a 1bpp 224 * 256 buffer.
+        The controller contains a video frame pool with multiple 1bpp frame buffers of
+        a custom size (to allow for rendering of custom widgets beyond the bounds of the vram)
+        to facillitate double/triple buffering when required.
     */
     class MemoryController final : public meen::IController
     {
-    private:
-        /** Memory size
-
-            The size in bytes of the memory.
-        */
-        //cppcheck-suppress unusedStructMember
-        size_t memorySize_{ 1 << 16 };
-
-        /** Memory buffer
-
-             The memory bytes that the cpu will read from and write to.
-        */
-        std::unique_ptr<uint8_t[]> memory_;
-
-        /** VRAM frame pool
-
-            A pool of recyclable video frames.
-        */
-        meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>> framePool_;
-
     public:
+        /** The width of each frame pool frame in bytes
+
+            MUST BE DIVISIBLE BY 8
+
+            @remark     Anything less than 36 will yield rendering errors on the border. Since we are compressed on width, we'd need some bitmath to render correctly which has not yet been implemented.
+            @remark     Since we are 1bpp, the width in pixels is 320.
+            @remark     Note the width is larger than the vram width to allow for addtional custom graphics blitting beyond the vram.
+
+            @todo       In the future this could become a user configurable parameter so that a custom surface size can be declared. It would then most likely involve the requirement
+                        of a callback of some sorts in which to render custom graphics to the surface.
+        */
+        static constexpr int frameWidth{ 40 }; 
+
+        /** The height of each frame pool frame in pixels
+
+            MUST BE DIVISIBLE BY 8
+
+            @remark     Note the height is larger than the vram width to allow for addtional custom graphics blitting beyond the vram.
+
+            @todo       In the future this could become a user configurable parameter so that a custom surface size can be declared. It would then most likely involve the requirement
+                        of a callback of some sorts in which to render custom graphics to the surface.
+        */
+        static constexpr int frameHeight{ 240 };
+
         /** Constructor
 
             Create a memory controller that can handle the memory requirements
-            of i8080 arcade. The emulated hardware runs on an Intel8080 with 64k
-            of memory therefore the memory controller will be of this size.
+            of i8080 arcade. This includes a 64k memory buffer along with a video
+            ram frame pool for single/double/triple buffered video frames for
+            optimised rendering.
 
-            @param      framePoolSize       The amount frames to allocate, each frame is 7168 bytes in length.
+            @param      framePoolSize       The amount frames to allocate, each frame will be width * height bytes in length.
 
             @remark     default frame pool size is 1.
 
             @see framePool_
         */
-        explicit MemoryController(int framePoolSize = 1);
+        MemoryController(int framePoolSize = 1);
 
         /** Destructor
 
@@ -86,9 +95,21 @@ namespace i8080_arcade
 
             The VideoFrame containing the current video ram is taken from a finite frame pool.
 
+            @param  screen  The screen to render.
+
             @return         The current video ram as a recyclable resource.
+            
+            @todo           The screen parameter needs to be the Screen enum defined in IIOController.h.
+                            Its definition needs to be moved to something like Types.h and the header
+                            needs to be included in this file.
         */
-        meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr GetVideoFrame() const;
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetVideoFrame(int screen) const;
+
+        /** Clear the memory
+        
+            Wipe the all the memory and frame pool frame buffers to 0.
+        */
+        void Clear();
 
         /** Read from controller
 
@@ -121,6 +142,65 @@ namespace i8080_arcade
             @return    The uuid as a 16 byte array.
         */
         std::array<uint8_t, 16> Uuid() const final;
+
+    private:
+        /** Memory size
+
+            The size in bytes of the memory.
+        */
+        //cppcheck-suppress unusedStructMember
+        static constexpr size_t memorySize_{ 1 << 16 };
+
+        /** The width of the vram
+
+            The 1bpp width in bytes of the vram that resides in memory.
+        */
+        static constexpr int vramWidth_{ 32 };
+        
+        /** The height of the vram
+ 
+            The vram that resides in memory in pixels.       
+        */
+        static constexpr int vramHeight_{ 224 };
+
+        /** VRAM size
+            
+            The total size in bytes.
+        */
+        static constexpr int vramSize_{ vramWidth_ * vramHeight_ };
+        
+        /** VRAM memory offset
+
+            The offset into memory at which the beginning of the vram resides.
+        */
+        static constexpr int vramOffset_{ 0x2400 };
+
+        /** VRAM centre offset
+
+            The offset from the beginning of the frame at which to blit the vram so that it is blitted in the middle of the frame.
+        */
+        static constexpr int centreOffset_{ (((frameHeight - vramHeight_) / 2) * frameWidth) + ((frameWidth - vramWidth_) / 2) };
+
+        /** Memory buffer
+
+             The memory bytes that the cpu will read from and write to.
+        */
+        std::vector<uint8_t> memory_;
+
+        /** VRAM frame pool
+
+            A pool of recyclable video frames.
+
+            See meen_hw/ResourcePool.h for further details.
+        */
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>> framePool_;
+
+        /**
+            Glyph renderer
+
+            See GlyphRenderer.h for further details.
+        */
+        GlyphRenderer glyphRenderer_{ 0 };
     };
 } // namespace i8080_arcade
 

--- a/include/i8080_arcade/MemoryController.h
+++ b/include/i8080_arcade/MemoryController.h
@@ -98,7 +98,7 @@ namespace i8080_arcade
             @param  screen  The screen to render.
 
             @return         The current video ram as a recyclable resource.
-            
+
             @todo           The screen parameter needs to be the Screen enum defined in IIOController.h.
                             Its definition needs to be moved to something like Types.h and the header
                             needs to be included in this file.
@@ -106,7 +106,7 @@ namespace i8080_arcade
         meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetVideoFrame(int screen) const;
 
         /** Clear the memory
-        
+
             Wipe the all the memory and frame pool frame buffers to 0.
         */
         void Clear();
@@ -156,19 +156,19 @@ namespace i8080_arcade
             The 1bpp width in bytes of the vram that resides in memory.
         */
         static constexpr int vramWidth_{ 32 };
-        
+
         /** The height of the vram
  
-            The vram that resides in memory in pixels.       
+            The vram that resides in memory in pixels.
         */
         static constexpr int vramHeight_{ 224 };
 
         /** VRAM size
-            
+
             The total size in bytes.
         */
         static constexpr int vramSize_{ vramWidth_ * vramHeight_ };
-        
+
         /** VRAM memory offset
 
             The offset into memory at which the beginning of the vram resides.

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -85,11 +85,15 @@ namespace i8080_arcade
         /** Centre height offset
 
             The difference in pixels of the height of the attached lcd panel and the height
-            of the i8080 arcahde video hardware.
+            of the i8080 arcade video hardware.
 
             This is used to centre the output frame on the lcd panel.
         */
         int heightOffset_{};
+
+        // The width/height of the memory controller frame buffers
+        int textureWidth_{};
+        int textureHeight_{};
 
         /** The previous video frame
 
@@ -101,7 +105,7 @@ namespace i8080_arcade
             frame being rendered. This allows for improved rendering performance by not rendering
             scanlines that are identical to the previous frame.
         */
-        meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr backBuffer_;
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr backBuffer_;
 
         /** i8080_arcade
 
@@ -127,7 +131,7 @@ namespace i8080_arcade
         */
         struct VideoFrameWrapper
         {
-            meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr videoFrame;
+            meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr videoFrame;
         };
 
         /** An array of resourcePtr wrappers for use with RP2040s C based queue api
@@ -151,7 +155,7 @@ namespace i8080_arcade
             0 we are in attraction screen mode and these buttons will be used
             to select which rom to load.
         */
-        int ships_{ -1 };
+        int ships_{};
 
         /** Button state tracking
 
@@ -164,6 +168,12 @@ namespace i8080_arcade
         bool lastK3_{};
 
         bool runAsync_{};
+
+        /** The current screen
+
+            See the Screen enumeration for further details.
+        */
+        Screen screen_{};
 
         /** LCD command
 
@@ -262,10 +272,12 @@ namespace i8080_arcade
             Create the video texture that will be rendered to the screen.
 
             @param  videoTextures   JSON object describing the video texture.
+            @param  textureWidth    The width of the videc texture in pixels.
+            @param  textureHeight   The height of the video texture in pixels.
 
 			@return					An error in the form of a std::error_code.
         */
-        std::error_code LoadVideoTextures(const JsonVariantConst videoTextures) final;
+        std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int textureWidth, int textureHeight) final;
 
    		/** Load Audio Samples
 

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -58,7 +58,7 @@ namespace i8080_arcade
 			SDL_Texture* texture_{};
 
 			/** Blitting rectangle.
-			
+
 				The destination bounding box within the SDL window to blit the video texture.
 			*/
 			//cppcheck-suppress unusedStructMember
@@ -137,7 +137,7 @@ namespace i8080_arcade
 			std::atomic_bool quit_{};
 
 			/** Load a game rom or the save state of the currently loaded game rom
-			
+
 				@remark		This value can be set from a different thread, hence it is atomic.
 			*/
 			std::atomic_bool loadSaveState_{};
@@ -166,14 +166,14 @@ namespace i8080_arcade
 			Uint8 lastY_{};
 
 			/** The running state
-			
+
 				True if meen is to run on a different thread to the main application,
 				false otherwise.
 			*/
 			bool runAsync_{};
 
 			/** The current screen
-			
+
 				See the Screen enumeration for further details.
 			*/
 			Screen screen_{};
@@ -182,14 +182,14 @@ namespace i8080_arcade
 
 				@param	port	The emulated port to read from.
 				@param	state	The keyboard state.
-				
+
 				@return			A uint8_t bitwise combination informing the rom
 								of the user input.
 			*/
 			uint8_t ReadInputDevice(uint8_t port, const uint8_t* state);
 
 			/** Assign a load or save machine interrupt
-			
+
 				Peforms a check of the key once during a key press and release sequence.
 
 				@param	key				The press or release state of the key.
@@ -296,8 +296,8 @@ namespace i8080_arcade
 			std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int frameWidth, int frameHeight) final;
 
 			/** Load the selected rom or the save state of the currently selected rom
-			
-				@param	maxSize			The total number of roms in the rom list	
+
+				@param	maxSize			The total number of roms in the rom list
 
 				@return					A tuple holding two values:
 										bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -23,6 +23,8 @@ SOFTWARE.
 #ifndef SDLIOCONTROLLER_H
 #define SDLIOCONTROLLER_H
 
+#define ARDUINOJSON_ENABLE_STRING_VIEW 1
+#include <ArduinoJson.h>
 #include <atomic>
 #include <SDL.h>
 #include <SDL_mixer.h>
@@ -54,6 +56,13 @@ namespace i8080_arcade
 			*/
 			//cppcheck-suppress unusedStructMember
 			SDL_Texture* texture_{};
+
+			/** Blitting rectangle.
+			
+				The destination bounding box within the SDL window to blit the video texture.
+			*/
+			//cppcheck-suppress unusedStructMember
+			SDL_Rect dstRect_{};
 
 			/** SDL_Window
 
@@ -102,7 +111,7 @@ namespace i8080_arcade
 			*/
 			struct VideoFrameWrapper
 			{
-				meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr videoFrame;
+				meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr videoFrame;
 			};
 
 			/** videoFrameWrapperPool_
@@ -162,6 +171,12 @@ namespace i8080_arcade
 				false otherwise.
 			*/
 			bool runAsync_{};
+
+			/** The current screen
+			
+				See the Screen enumeration for further details.
+			*/
+			Screen screen_{};
 
 			/** Read input form the keyboard
 
@@ -278,7 +293,7 @@ namespace i8080_arcade
 
 				@return					An error in the form of a std::error_code.
 			*/
-			std::error_code LoadVideoTextures(const JsonVariantConst videoTextures) final;
+			std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int frameWidth, int frameHeight) final;
 
 			/** Load the selected rom or the save state of the currently selected rom
 			

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -84,8 +84,8 @@ namespace i8080_arcade
                     *p1 = rpm & 0xFF;
 
                     // This will keep the remaining pixels in the frame buffer
-                    //*p0 |= lpm;
-                    //*p1 |= rpm;
+                    // *p0 |= lpm;
+                    // *p1 |= rpm;
                 }
             };
 
@@ -98,7 +98,7 @@ namespace i8080_arcade
             {
                 if (vramWidth_ == frameWidth)
                 {
-                    std::ranges::copy_n(memory_.begin() + vramOffset_, vramWidth_ * vramHeight_, frame->begin());
+                    std::ranges::copy_n(memory_.begin() + vramOffset_, vramSize_, frame->begin());
                 }
                 else
                 {
@@ -140,7 +140,7 @@ namespace i8080_arcade
         do
         {
             frame = framePool_.GetResource();
-            
+
             if (frame == nullptr)
             {
                 empty = true;

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -51,6 +51,7 @@ namespace i8080_arcade
 
         glyphRenderer_ = GlyphRenderer(frameWidth);
         //glyphRenderer_.SetText("   BALLOON BOMBER   \n\n\n   LUNAR RESCUE   \n\n\n   TAITO   \n\n   SPACE INVADERS II   \n\n\n   MIDWAY   \n\n   SPACE INVADERS II   \n\n\n   SPACE INVADERS   ");
+        // todo: need to pass in the rom names from the config file in order to generated the render text
         glyphRenderer_.SetText(" BALLOON BOMBER \n\n\n LUNAR RESCUE \n\n\n TAITO \n\n SPACE INVADERS II \n\n\n MIDWAY \n\n SPACE INVADERS II \n\n\n SPACE INVADERS ");
         glyphRenderer_.SetJustification(GlyphRenderer::Justification::Centre);
         glyphRenderer_.SetFont(GlyphRenderer::Font::I8080ArcadeRegular8x8);

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -27,28 +27,137 @@ SOFTWARE.
 namespace i8080_arcade
 {
     MemoryController::MemoryController(int framePoolSize)
-        : memory_{ std::make_unique<uint8_t[]>(memorySize_) }
     {
-        framePool_ = meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>();
+        memory_.resize(memorySize_, 0);
+        framePool_ = meen_hw::MH_ResourcePool<std::vector<uint8_t>>();
+
+        static_assert((frameWidth * frameHeight) >= (vramSize_));
 
         for(int i = 0; i < framePoolSize; i++)
         {
-            framePool_.AddResource(new std::array<uint8_t, 7168>);
+            framePool_.AddResource(new std::vector<uint8_t>(frameWidth * frameHeight, 0));
         }
 
-        std::ranges::fill(memory_.get(), memory_.get() + memorySize_, 0x00);
+        auto setAnchorPoint = [this](bool setAnchorPoint)
+        {
+            if (setAnchorPoint == true)
+            {
+                // determine the offset at which to blit the text - we want to center the text on the surface
+                int widthOffset = (vramWidth_ - glyphRenderer_.GetWidth()) / 2;
+                int heightOffset = ((vramHeight_ - glyphRenderer_.GetHeight()) / 2) * frameWidth;
+                glyphRenderer_.SetAnchorPoint(centreOffset_ + widthOffset + heightOffset);
+            }
+        };
+
+        glyphRenderer_ = GlyphRenderer(frameWidth);
+        //glyphRenderer_.SetText("   BALLOON BOMBER   \n\n\n   LUNAR RESCUE   \n\n\n   TAITO   \n\n   SPACE INVADERS II   \n\n\n   MIDWAY   \n\n   SPACE INVADERS II   \n\n\n   SPACE INVADERS   ");
+        glyphRenderer_.SetText(" BALLOON BOMBER \n\n\n LUNAR RESCUE \n\n\n TAITO \n\n SPACE INVADERS II \n\n\n MIDWAY \n\n SPACE INVADERS II \n\n\n SPACE INVADERS ");
+        glyphRenderer_.SetJustification(GlyphRenderer::Justification::Centre);
+        glyphRenderer_.SetFont(GlyphRenderer::Font::I8080ArcadeRegular8x8);
+        setAnchorPoint(true);
+        //setAnchorPoint(!!glyphRenderer_.Update(">>"));
+        //setAnchorPoint(!!glyphRenderer_.Update("<<", 18));
     }
 
-    meen_hw::MH_ResourcePool<std::array<uint8_t, 7168>>::ResourcePtr MemoryController::GetVideoFrame() const
+    meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MemoryController::GetVideoFrame(int screen) const
     {
         auto frame = framePool_.GetResource();
 
         if(frame != nullptr)
         {
-            std::ranges::copy_n(memory_.get() + 0x2400, frame->size(), frame->begin());
+            // Thos dpes not take into account bounds checks ... negative values here will result in ub
+            auto blitBorder = [frameBegin = frame->begin()](int x0Start, int x1Start, int width, int y0Start, int y1Start, int height, int lpm, int rpm)
+            {
+                auto p1 = frameBegin + x1Start;
+
+                for (auto p0 = frameBegin + x0Start; p0 < frameBegin + x0Start + width; std::advance(p0, 1), std::advance(p1, 1))
+                {
+                    *p0 = *p1 = 0xFF;
+                }
+
+                p1 = frameBegin + y1Start;
+
+                for (auto p0 = frameBegin + y0Start; p0 < frameBegin + ((height - 1) * frameWidth); std::advance(p0, frameWidth), std::advance(p1, frameWidth))
+                {
+                    *p0 = lpm & 0xFF;
+                    *p1 = rpm & 0xFF;
+
+                    // This will keep the remaining pixels in the frame buffer
+                    //*p0 |= lpm;
+                    //*p1 |= rpm;
+                }
+            };
+
+            // blit a border around the surface
+            blitBorder(0, frame->size() - frameWidth, frameWidth, frameWidth, frameWidth * 2 - 1, frameHeight, 0x01, 0x80);
+            // blit a border around the vram
+            blitBorder(centreOffset_ - frameWidth, centreOffset_ + (vramHeight_ * frameWidth), vramWidth_, centreOffset_ - frameWidth - 1, centreOffset_ + vramWidth_ - frameWidth, vramHeight_ + 10, 0x80, 0x01);
+
+            if (screen == 1 /* Screen::Gameplay */)
+            {
+                if (vramWidth_ == frameWidth)
+                {
+                    std::ranges::copy_n(memory_.begin() + vramOffset_, vramWidth_ * vramHeight_, frame->begin());
+                }
+                else
+                {
+                    auto it = frame->begin() + centreOffset_;
+                    //auto vramStart = memory_.begin() + vramOffset_;
+
+                    for (auto vram = memory_.cbegin() + vramOffset_; vram < memory_.cbegin() + vramOffset_ + vramSize_; std::advance(vram, vramWidth_), std::advance(it, frameWidth))
+                    {
+                        std::ranges::copy_n(vram, vramWidth_, it);
+                    }
+                }
+            }
+            else
+            {
+                // rom selection
+                auto errc = glyphRenderer_.Blit(frame->begin(), frame->end(), 0 /* invert one line */, 16 /* starting at line 16 */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
+
+                if (errc)
+                {
+                    printf("Failed to blit text: %s\n", errc.message().c_str());
+                }
+            }
+
+            // blit additional metadata here
         }
 
         return frame;
+    }
+
+    void MemoryController::Clear()
+    {
+        std::vector<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr> frames;
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr frame;
+        bool empty = false;
+
+        // Clear the memory to 0
+        memory_.assign(memory_.size(), 0);
+
+        do
+        {
+            frame = framePool_.GetResource();
+            
+            if (frame == nullptr)
+            {
+                empty = true;
+            }
+            else
+            {
+                // Clear the vram section of the video frames
+                for (auto vram = frame->begin() + centreOffset_; vram < frame->cbegin() + centreOffset_ + (vramHeight_ * frameWidth); std::advance(vram, frameWidth))
+                {
+                    std::ranges::fill(vram, vram + vramWidth_, 0);
+                }
+
+                frames.emplace_back(std::move(frame));
+            }
+        }
+        while(empty == false);
+
+        // frames will get returned to the pool once this method returns.
     }
 
     uint8_t MemoryController::Read(uint16_t addr, [[maybe_unused]] meen::IController* controller)

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -47,10 +47,6 @@ namespace i8080_arcade
         width_ = videoHardware["width"].as<int>();
         height_ = videoHardware["height"].as<int>();
 
-        // Used to center the video ram on the display
-        widthOffset_ = (width_ - i8080ArcadeIO_->GetVRAMWidth()) / 2;
-        heightOffset_ = (height_ - i8080ArcadeIO_->GetVRAMHeight()) / 2;
-
         queue_init(&videoFrameQueue_, sizeof(uintptr_t), 2);
         queue_init(&freeQueue_, sizeof(uintptr_t), 2);
 
@@ -60,7 +56,6 @@ namespace i8080_arcade
             queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
         }
 
-        stdio_init_all();
         spi_init(spi1, 62.5 * 1000000);
 
         gpio_set_function(Pin::CLK, GPIO_FUNC_SPI);
@@ -173,7 +168,7 @@ namespace i8080_arcade
         queue_free(&videoFrameQueue_);
     }
 
-    std::error_code RPIoController::LoadVideoTextures(const JsonVariantConst videoTextures)
+    std::error_code RPIoController::LoadVideoTextures(const JsonVariantConst videoTextures, int textureWidth, int textureHeight)
     {
         int bpp = 16; // this needs to be updated to 12bpp for performance reasons
 
@@ -207,7 +202,13 @@ namespace i8080_arcade
 
         i8080ArcadeIO_->SetOptions(meenConfig.c_str());
         // We decompress and write one scanline at a time to lcd ram
-        texture_.resize((i8080ArcadeIO_->GetVRAMWidth() * bpp) / 8); // 8 - bits per pixel
+        texture_.resize((textureWidth * bpp) / 8); // 8 - bits per pixel
+        // Used to center the video ram on the display
+        widthOffset_ = (width_ - textureWidth) / 2;
+        heightOffset_ = (height_ - textureHeight) / 2;
+        textureWidth_ = textureWidth;
+        textureHeight_ = textureHeight;
+
         return std::error_code{};
     }
 
@@ -237,54 +238,62 @@ namespace i8080_arcade
         {
             if (port == 1)
             {
-                // Always force single player mode (0x04) (2P mode is not supported)
+                // The 4th bit is always set (0x08).
+                // This demo moves straight to a 1P game as soon as a credit is entered (no 2P support),
+                // therefore we always set it (0x04) (it will be ignored if no credits exist)
                 ret = 0x08 | 0x04;
-                ret |= ButtonPress(!gpio_get(Pin::K1), lastK1_) * 0x01; // Credit
 
-                if (ships_ > 0)
+                if (ButtonPress(!gpio_get(Pin::K1), lastK1_))
                 {
-                    // We want button repeats during gameplay for player movement
-                    ret |= !gpio_get(Pin::K0) * 0x20; // 1P Left
-                    ret |= !gpio_get(Pin::K3) * 0x40; // 1P Right
-                    ret |= ButtonPress(!gpio_get(Pin::K2), lastK2_) * 0x10; // 1P Fire
+// todo: all frame buffers need to be returned to the memory controller so they can be cleared
+#if 0
+                    backBuffer_ = nullptr;
+                    VideoFrameWrapper* vfw = nullptr;
+                    queue_try_remove(&videoFrameQueue_, static_cast<void*>(&vfw));
 
-                    if (ret & 0x01)
+                    if (vfw != nullptr)
                     {
-                        //ships_ = 0;
-                        // turn off credit
-                        ret &= ~0x01;
-                        //printf("Quitting mid game\n");
-                        // TODO: We are playing a game, we need to quit back to the attraction screen, we need to issue a quit event to pass back to the main
-                        // function so we can reset the machine
+                        printf("Cancel frames\n");
+
+                        while(vfw != nullptr)
+                        {
+                            printf("Return frame to pool\n");
+                            auto videoFrame = std::move(vfw->videoFrame);
+                            // explicitly set to nullptr as there is no requirement on std::move to do this
+                            vfw->videoFrame = nullptr;
+                            auto p = std::bit_cast<uintptr_t>(vfw);
+                            queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
+
+                            vfw = nullptr;
+                            queue_try_remove(&videoFrameQueue_, static_cast<void*>(&vfw));
+                        }
+
+                        printf("End cancel frames\n");
                     }
+#endif
+                    screen_ = Screen::RomSelect;
+                    // Clear the memmory so the loaded rom code is not executed during the rom select screen.
+                    static_cast<MemoryController*>(memoryController)->Clear();
                 }
                 else
                 {
-                    // When scrolling roms we DONT want button repeats
-                    ret |= ButtonPress(!gpio_get(Pin::K0), lastK0_) * 0x20;
-                    ret |= ButtonPress(!gpio_get(Pin::K3), lastK3_) * 0x40;
-
-                    if (ret & 0x01)
+                    if (ships_ > 0)
                     {
-                        //printf("Game start\n");
-                        // We are starting a game, set the amount of ships (this could be also 4/5/6 if this demo supported setting the ship count)
-                        ships_ = 3;
+                        // We want button repeats during gameplay for player movement
+                        ret |= !gpio_get(Pin::K0) * 0x20; // 1P Left
+                        ret |= !gpio_get(Pin::K3) * 0x40; // 1P Right
+                        ret |= ButtonPress(!gpio_get(Pin::K2), lastK2_) * 0x10; // 1P Fire
                     }
-
-                    if (ret & 0x20)
+                    else
                     {
-                        //printf("Move to the previous rom\n");
-                        // turn off move left
-                        ret &= ~0x20;
-                        // TODO: We want move to the previous rom, send previous rom event
-                    }
-
-                    if (ret & 0x40)
-                    {
-                        //printf("Move to the next rom\n");
-                        // turn off move right
-                        ret &= ~0x40;
-                        // TODO: We want move to the next rom, send next rom event
+                        if (ButtonPress(!gpio_get(Pin::K0), lastK0_))
+                        {
+                            // Add a credit
+                            ret |= 0x01;
+                            // Move straight to a 1P game.
+                            // Set the amount of ships (this could be also 4/5/6 if this demo supported setting the ship count)
+                            ships_ = 3;
+                        }
                     }
                 }
             }
@@ -329,12 +338,13 @@ namespace i8080_arcade
         {
             case 0:
             {
-                if (ships_ == -1)
+                if (screen_ == Screen::RomSelect)
                 {
                     // Check button 2 press to trigger a rom load interrupt
-                    if (ButtonPress (!gpio_get(Pin::K2), lastK2_))
+                    if (ButtonPress (!gpio_get(Pin::K2), lastK2_)) // we may need to set a callbcak on the pin since the press could be missed
                     {
                         isr = meen::ISR::Load;
+                        screen_ = Screen::Gameplay;
                         ships_ = 0;
                     }
                 }
@@ -352,7 +362,7 @@ namespace i8080_arcade
 
                 if (success == true)
                 {
-                    vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetVideoFrame();
+                    vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetVideoFrame(screen_);
 
                     if(vfw->videoFrame != nullptr)
                     {
@@ -451,9 +461,7 @@ namespace i8080_arcade
 
         if (videoFrame != nullptr)
         {
-            auto arcadeWidth = i8080ArcadeIO_->GetVRAMWidth();
-            auto arcadeHeight = i8080ArcadeIO_->GetVRAMHeight();
-            auto compressedWidth = arcadeWidth >> 3;
+            auto compressedWidth = textureWidth_ >> 3;
             auto dst = texture_.data();
             auto dstSize = texture_.size();
             auto dst16 = std::bit_cast<uint16_t*>(dst);
@@ -468,7 +476,7 @@ namespace i8080_arcade
             gpio_put(Pin::DC, 1);
             gpio_put(Pin::CS, 0);
 
-            for(int i = 0/*, lastScanline = 0*/; i < arcadeHeight; i++)
+            for(int i = 0/*, lastScanline = 0*/; i < textureHeight_; i++)
             {
                 // Blit a scanline at a time for performance reasons
 
@@ -499,8 +507,8 @@ namespace i8080_arcade
                         }
 
                         // Blit and render the current scanline
-                        i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), dstSize, std::span(vf, compressedWidth));
-                        spi_write16_blocking(spi1, dst16, arcadeWidth);
+                        i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), textureWidth_, dstSize, std::span(vf, compressedWidth), MemoryController::frameWidth);
+                        spi_write16_blocking(spi1, dst16, textureWidth_);
 
                         // Update the last scanline index
                         //lastScanline = i;
@@ -513,8 +521,8 @@ namespace i8080_arcade
                 }
                 else
                 {
-                    i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), dstSize, std::span(vf, compressedWidth));
-                    spi_write16_blocking(spi1, dst16, arcadeWidth);
+                    i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), textureWidth_, dstSize, std::span(vf, compressedWidth), MemoryController::frameWidth);
+                    spi_write16_blocking(spi1, dst16, textureWidth_);
                 }
 
                 // Move to the next scanline in the front buffer

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -543,7 +543,7 @@ namespace i8080_arcade
 
 										if (SDL_LockTexture(texture_, nullptr, std::bit_cast<void**>(&dst), &rowBytes) == 0)
 										{
-											i8080ArcadeIO_->BlitVRAM(std::span(dst, dstRect_.h * rowBytes), dstRect_.w, rowBytes, std::span(*videoFrame), 34); // 32 - needs to be MemoryController::frameWidth
+											i8080ArcadeIO_->BlitVRAM(std::span(dst, dstRect_.h * rowBytes), dstRect_.w, rowBytes, std::span(*videoFrame), MemoryController::frameWidth);
 											SDL_UnlockTexture(texture_);
 										}
 										else

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -133,10 +133,10 @@ namespace i8080_arcade
 
 	std::error_code SDLIoController::LoadAudioSamples(const JsonVariantConst audio)
 	{
-		auto scheme = audio["scheme"].as<std::string>();
-		auto directory = audio["directory"].as<std::string>();
+		auto scheme = audio["scheme"].as<std::string_view>();
+		auto directory = audio["directory"].as<std::string_view>();
 
-		auto addChunk = [&mixChunk = mixChunk_](const std::string& directory, const std::string& resource)
+		auto addChunk = [&mixChunk = mixChunk_](std::string_view directory, std::string_view resource)
 		{
 			// if we want to add the additional '/' (so we don't have to put it in the config file)
 			// we need to check if the directory is empty first
@@ -154,11 +154,11 @@ namespace i8080_arcade
 		for(const auto& sample : audio["sample"].as<JsonArrayConst>())
 		{
 			auto dir = directory;
-			auto resource = sample.as<std::string>();
+			auto resource = sample.as<std::string_view>();
 
 			if (resource.starts_with("file://"))
 			{
-				resource.erase(strlen("file://"));
+				resource.remove_prefix(strlen("file://"));
 				// A resource starting with a scheme specifies the exact location of that resource
 				dir = "";
 			}
@@ -181,8 +181,10 @@ namespace i8080_arcade
 		return std::error_code{};
 	}
 
-	std::error_code SDLIoController::LoadVideoTextures(const JsonVariantConst videoTextures)
+	std::error_code SDLIoController::LoadVideoTextures(const JsonVariantConst videoTextures, int textureWidth, int textureHeight)
 	{
+		int windowWidth = 0;
+		int windowHeight = 0;
 		std::string meenConfig;
 		serializeJson(videoTextures, meenConfig);
 
@@ -219,14 +221,29 @@ namespace i8080_arcade
 			return std::make_error_code (std::errc::io_error);
 		}
 
+		// swap width/height based on orientation
+		if (videoTextures["orientation"].as<std::string>() == "upright")
+		{
+			textureWidth ^= textureHeight ^= textureWidth ^= textureHeight;
+		}
+
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-		texture_ = SDL_CreateTexture(renderer_, pf, SDL_TEXTUREACCESS_STREAMING, i8080ArcadeIO_->GetVRAMWidth(), i8080ArcadeIO_->GetVRAMHeight());
+		texture_ = SDL_CreateTexture(renderer_, pf, SDL_TEXTUREACCESS_STREAMING, textureWidth, textureHeight);
 
 		if (texture_ == nullptr)
 		{
 			return std::make_error_code (std::errc::not_enough_memory);
 		}
 
+		if (SDL_QueryTexture(texture_, nullptr, nullptr, &dstRect_.w, &dstRect_.h) < 0)
+		{
+			return std::make_error_code(std::errc::not_enough_memory);
+		}
+
+		// Position the destination blitting rectangle in the middle of the screen.
+		SDL_GetWindowSize(window_, &windowWidth, &windowHeight);
+		dstRect_.x = (windowWidth - dstRect_.w) / 2;
+		dstRect_.y = (windowHeight - dstRect_.h) / 2;
 		return std::error_code{};
 	}
 
@@ -296,7 +313,7 @@ namespace i8080_arcade
 					// thread and waits for a result ... I don't think we can
 					// remove this and just perform the else case as I don't think
 					// it is safe to do so with SDL across threads.
-					std::promise<uint8_t> p;
+					std::promise<uint16_t> p;
 					SDL_Event e{};
 					e.type = siEvent_;
 					e.user.code = EventCode::ReadInput;
@@ -306,12 +323,55 @@ namespace i8080_arcade
 
 					if (quit_ == false)
 					{
-						ret = p.get_future().get();
+						auto val = p.get_future().get();
+
+						if (val <= 0xFF)
+						{
+							ret = static_cast<uint8_t>(val);
+						}
+						else
+						{
+							screen_ = Screen::RomSelect;
+							// Clear the memory controller ram and frame buffers
+							static_cast<MemoryController*>(controller)->Clear();
+						}
 					}
 				}
 				else
 				{
-					ret = ReadInputDevice(port, SDL_GetKeyboardState(nullptr));
+					auto kbState = SDL_GetKeyboardState(nullptr);
+
+					if (kbState[SDL_SCANCODE_ESCAPE] == false)
+					{
+						ret = ReadInputDevice(port, kbState);
+					}
+					else
+					{
+						SDL_Event e;
+
+						// In single threaded mode we need to abort the current frame to be rendered and return the wrapper
+						// and its frame to their respective pools so that the frame can be cleared.
+						if (SDL_PollEvent(&e))
+						{
+							if (e.type == siEvent_ && e.user.code == EventCode::RenderVideo)
+							{
+								auto videoFrameWrapper = std::bit_cast<VideoFrameWrapper*>(e.user.data1);
+
+								if (videoFrameWrapper != nullptr)
+								{
+									auto videoFrame = std::move(videoFrameWrapper->videoFrame);
+									// We are single threaded, so we don't need to lock this.
+									videoFrameWrapperPool_.push_back(std::unique_ptr<VideoFrameWrapper>(videoFrameWrapper));
+								}
+							}
+						}
+
+						screen_ = Screen::RomSelect;
+						// Clear the memory controller ram and frame buffers
+						static_cast<MemoryController*>(controller)->Clear();
+
+						// todo: for the RPIoController we need to clear the back buffer
+					}
 				}
 			}
 		}
@@ -345,6 +405,19 @@ namespace i8080_arcade
 			case 0:
 			{
 				isr = loadSaveInterrupt_.exchange(meen::ISR::NoInterrupt);
+
+				if (isr == meen::ISR::Load && screen_ == Screen::RomSelect)
+				{
+					if (loadSaveState_ == false)
+					{
+						// We are loading a rom, move to the game play screen
+						screen_ = Screen::Gameplay;
+					}
+				}
+				else if (loadSaveState_ == false)
+				{
+					isr = meen::ISR::NoInterrupt;
+				}
 				break;
 			}
 			case 1:
@@ -368,8 +441,7 @@ namespace i8080_arcade
 
 				if(videoFrameWrapper != nullptr)
 				{
-					// GetVideoFrame accepts a parameter for rom select screen or game play, memory controller will generate the next rom select frame or game play frame
-					videoFrameWrapper->videoFrame = static_cast<MemoryController*>(memoryController)->GetVideoFrame();
+					videoFrameWrapper->videoFrame = static_cast<MemoryController*>(memoryController)->GetVideoFrame(screen_);
 				}
 
 				SDL_Event e{};
@@ -471,7 +543,7 @@ namespace i8080_arcade
 
 										if (SDL_LockTexture(texture_, nullptr, std::bit_cast<void**>(&dst), &rowBytes) == 0)
 										{
-											i8080ArcadeIO_->BlitVRAM(std::span(dst, i8080ArcadeIO_->GetVRAMHeight() * rowBytes), rowBytes, std::span(*videoFrame));
+											i8080ArcadeIO_->BlitVRAM(std::span(dst, dstRect_.h * rowBytes), dstRect_.w, rowBytes, std::span(*videoFrame), 34); // 32 - needs to be MemoryController::frameWidth
 											SDL_UnlockTexture(texture_);
 										}
 										else
@@ -489,10 +561,13 @@ namespace i8080_arcade
 									printf("Wrapper empty, video frame dropped\n");
 								}
 
-								SDL_RenderCopy(renderer_, texture_, nullptr, nullptr);
+								SDL_RenderCopy(renderer_, texture_, nullptr, &dstRect_);
 								SDL_RenderPresent(renderer_);
 
-								// Check to see if the user wants to load a rom
+								// Check to see if the user wants to load a rom.
+								// This will only be acknowledged in ServiceInterrupts if screen_ is RomSelect,
+								// we could check screen_ for RomSelect here, but that would mean select_ would have
+								// to be atomic.
 								lastU_ = SetInterrupt(state[SDL_SCANCODE_U], lastU_, meen::ISR::Load, false);
 								break;
 							}
@@ -520,9 +595,8 @@ namespace i8080_arcade
 							case EventCode::ReadInput:
 							{
 								uint8_t port = reinterpret_cast<uint64_t>(e.user.data1);
-								auto p = static_cast<std::promise<uint8_t>*>(e.user.data2);
-								auto value = ReadInputDevice(port, state);
-								p->set_value(value);
+								auto p = static_cast<std::promise<uint16_t>*>(e.user.data2);								
+								state[SDL_SCANCODE_ESCAPE] ? p->set_value(0x100) :  p->set_value(ReadInputDevice(port, state));
 								break;
 							}
 							default:

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -516,7 +516,7 @@ namespace i8080_arcade
 											{
 												static_cast<std::promise<uint8_t>*>(e.user.data2)->set_value(0);
 											}
-										}	
+										}
 									}
 									break;
 								}
@@ -582,6 +582,17 @@ namespace i8080_arcade
 
 								for (int i = 0; i < 8; i++)
 								{
+									/*
+										todo: if the audio is ufo, we need to loop it rather than playing the sample again.
+											  this should fix the stall in single threaded mode
+
+										if audio.test(i) is ufo and ufo not playing
+											mix play channel (repeat the sample)
+
+										if audio.test(i) != ufo and ufo playing
+											mix play channel (stop the sample)
+									*/
+
 									if (audio.test(i) == true)
 									{
 										[[maybe_unused]] auto busy = Mix_PlayChannel(-1 /* use the next available channel */, mixChunk_[i + offset], 0 /* don't loop (play it once) */);
@@ -595,7 +606,7 @@ namespace i8080_arcade
 							case EventCode::ReadInput:
 							{
 								uint8_t port = reinterpret_cast<uint64_t>(e.user.data1);
-								auto p = static_cast<std::promise<uint16_t>*>(e.user.data2);								
+								auto p = static_cast<std::promise<uint16_t>*>(e.user.data2);
 								state[SDL_SCANCODE_ESCAPE] ? p->set_value(0x100) :  p->set_value(ReadInputDevice(port, state));
 								break;
 							}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -182,7 +182,7 @@ int main(int argc, char** argv)
 		// Set up the custom controllers prior to configuring the machine.
 
 		// The memory controller width and height is in the native i8080 arcade pixel format (1bpp cocktail) so we need to multiply it by 8 to get the total pixel width
-		// in order to create a compatible sdl texture
+		// in order to create a compatible texture
 		auto err = ioController->LoadVideoTextures(software["video"], i8080_arcade::MemoryController::frameWidth << 3, i8080_arcade::MemoryController::frameHeight);
 		CHECK_ERROR(err, printf("Failed to load video textures: %s\n", err.message().c_str()));
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -79,8 +79,12 @@ static i8080_arcade::MemoryController* MakeMemoryController()
 #endif
 }
 
-static i8080_arcade::IIoController* MakeIoController(bool runAsync, const JsonVariant& audioHardware, const JsonVariant& videoHardware)
+static i8080_arcade::IIoController* MakeIoController(bool runAsync, JsonVariantConst audioHardware, JsonVariantConst videoHardware)
 {
+	if (!audioHardware|| !videoHardware)
+	{
+		return nullptr;
+	}
 #ifdef ENABLE_MH_RP2040
 	return new i8080_arcade::RPIoController(runAsync, audioHardware, videoHardware);
 #else
@@ -177,7 +181,9 @@ int main(int argc, char** argv)
 
 		// Set up the custom controllers prior to configuring the machine.
 
-		auto err = ioController->LoadVideoTextures(software["video"]);
+		// The memory controller width and height is in the native i8080 arcade pixel format (1bpp cocktail) so we need to multiply it by 8 to get the total pixel width
+		// in order to create a compatible sdl texture
+		auto err = ioController->LoadVideoTextures(software["video"], i8080_arcade::MemoryController::frameWidth << 3, i8080_arcade::MemoryController::frameHeight);
 		CHECK_ERROR(err, printf("Failed to load video textures: %s\n", err.message().c_str()));
 
 		err = ioController->LoadAudioSamples(software["audio"]);


### PR DESCRIPTION
Adds a rom selection screen:
- At this point, it is just a visual and cannot be interacted with (future pr).
- SDL io controller: Pressing the 'u' key will load the default rom (space invaders) and pressing the `esc` will return back to the rom selection screen.
- RP2040 io contoller: pressing button 2 will load the default rom (space invaders) and pressing button 1 will return back to the rom selection screen. Pressing button 0 when the default rom is loaded will start a single player game.
- The memory controller is now responsible for blitting all screen types (see Screen enumeration).
- The memory controller now supports defining a frame buffer larger than the internal vram so that custom graphics can be rendered.
- All memory controller graphics are blitted in the center of main frame buffer.