### PR TITLE
#86 feat: run time rom selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ This project uses [CMake (minimum version 3.23)](https://cmake.org/) for its bui
 - `conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.1.0"`
 
 **2.** Install dependencies:
-- Windows msvc x86_64 build and host: `conan install . --build=missing --profile:build=Windows-x86_64-msvc-193 --profile:host=profiles/Windows-x86_64-msvc-193-sdl`.
-- Linux x86_64 build and host: `conan install . --build=missing --profile:build=Linux-x86_64-gcc-13 --profile:host=profiles/Linux-x86_64-gcc-13-sdl`.
-- Linux x86_64 build, Linux armv7hf host: `conan install . --build=missing -profile:build=Linux-x86_64-gcc-13 -profile:host=profiles/Linux-armv7hf-gcc-13-sdl`.
-- Linux x86_64 build, Linux armv8 host: `conan install . --build=missing -profile:build=Linux-x86_64-gcc-13 -profile:host=profiles/Linux-armv8-gcc-13-sdl`.
-- Linux x86_64 build, RP2040 microcontroller (baremetal armv6-m) host: `conan install . --build=missing -profile:build=Linux-x86_64-gcc-13 -profile:host=profiles/rp2040-armv6-gcc-13-st7789vw`.<br>
+- Windows msvc x86_64 build and host: `conan install . --build=missing --profile:all=profiles/Windows-x86_64-msvc-193-sdl`.
+- Linux x86_64 build and host: `conan install . --build=missing --profile:all=profiles/Linux-x86_64-gcc-13-sdl`.
+- Linux x86_64 build, Linux armv7hf host: `conan install . --build=missing --profile:build=Linux-x86_64-gcc-13 --profile:host=profiles/Linux-armv7hf-gcc-13-sdl`.
+- Linux x86_64 build, Linux armv8 host: `conan install . --build=missing --profile:build=Linux-x86_64-gcc-13 --profile:host=profiles/Linux-armv8-gcc-13-sdl`.
+- Linux x86_64 build, RP2040 microcontroller (baremetal armv6-m) host: `conan install . --build=missing --profile:build=Linux-x86_64-gcc-13 --profile:host=profiles/rp2040-armv6-gcc-13-st7789vw`.<br>
 
 **NOTE**: when performing a cross compile using a host profile you must install the requisite toolchain of the target architecture, [see pre-requisites](#pre-requisites).
 
@@ -224,8 +224,8 @@ The current settings for these options should be sufficient, changing them may h
 
 Video hardware options. These options can be changed for the desired output.
 
-`width:224` - The width of the screen in pixels. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
-`height:256` - The height of the screen in pixels. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
+`width:320` - The width of the screen in pixels. For upright orientation, the minimum support width of the display is 240, for cocktail, 320.<br>
+`height:240` - The height of the screen in pixels. For upright orientation, the minimum supported height of the display is 320, for cocktail, 240.<br>
 `fullScreen:false` - Window or full screen display. (Experimental)<br>
 
 **NOTE**: the RP IO Controller does not support scaling or full-screen, the width and height parameters will be used to center the output on the display device.
@@ -249,9 +249,9 @@ These settings apply to the various arcade roms that can be loaded.
 
 These settings affect visual output and can be changed. They apply to all game roms loaded.
 
-`bpp:8` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
+`bpp:16` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
 `colour:white` - The forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and a 16 bit custom hex value.<br>
-`orientation:upright` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
+`orientation:cocktail` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
 
 **NOTE**: the RP IO Controller only supports cocktail orientation @ 16bpp.
 
@@ -277,10 +277,12 @@ These settings are fixed to the specified rom.
 `memory:rom:[block]:bytes`: The rom resource to load. When the resource is fully qualified it will ignore the scheme and directory parameters.
 `memory:rom:[block]:offset`: The offset into memory where the rom will be loaded, this value **must** not be changed, doing so will yield undefined behaviour.<br>
 
+**NOTE**: The rom name is used for the entry in the rom selection screen. It **must** not have any new line characters and **must** only contain characters defined in the supported font defined in `GlyphRenderer.cpp`. The maximum number of characters supported per entry is 26 ((the vram width (224) / the supported font width (8)) - 2 spaces (one is prepended and one is appeneded to the name)). 
+
 ### Desktop Keyboard Controls
 
-`q`: Quit<br>
-`c`: Credit<br>
+`q`: quit<br>
+`c`: credit<br>
 `1`: 1P<br>
 `2`: 2P<br>
 `a`: 1P left<br>
@@ -290,16 +292,18 @@ These settings are fixed to the specified rom.
 `4`: 4 ships<br>
 `5`: 5 ships<br>
 `6`: 6 ships<br>
-`t`: Tilt<br>
-`e`: Extra ship at<br>
+`t`: tilt<br>
+`e`: extra ship at<br>
 `j`: 2P left<br>
 `k`: 2P fire<br>
 `l`: 2P right<br>
-`i`: Show coin info<br>
-`y`: Save game<br>
-`r`: Load save game<br>
-`u`: Load from rom<br>
-`esc`: Return to the rom selection screen<br> 
+`i`: show coin info<br>
+`y`: save game<br>
+`r`: load save game<br>
+`up`: move to the prevous rom<br>
+`down`: move to the next rom<br>
+`enter`: load the selected rom<br>
+`esc`: return to the rom selection screen<br> 
 
 ### Embedded button controls
 
@@ -310,10 +314,10 @@ More buttons and/or logic can be added for a more complete emulation, 2 player s
 
 The pin layout used is the same as the [hardware lcd](https://www.waveshare.com/wiki/Pico-LCD-2) used for testing.
 
-`button 0`: when on the rom attraction screen, select the previous rom in the list of supported roms, when in gameplay mode, move the ship to the left.
-`button 1`: when on the rom attraction screen, add a credit and start a single player game, when in gameplay mode, quit and return to the attraction screen.
-`button 2`: when in gameplay mode, fire at the enemy.
-`button 3`: when on the rom attraction screen, select the next rom in the list of supported roms, when in gameplay mode, move the ship to the right.
+`button 0`: when on the loaded roms attraction screen, start a 1P game, when in gameplay mode, move the ship to the left.
+`button 1`: when in gameplay mode, quit and return to the rom selection screen.
+`button 2`: when on the rom selection screen, select the previous rom in the list of supported roms, when in gameplay mode, fire at the enemy.
+`button 3`: when on the rom selection screen, select the next rom in the list of supported roms, when in gameplay mode, move the ship to the right.
 
 ![space-invaders](docs/images/space-invaders.png) ![space-invaders-deluxe](docs/images/space-invaders-deluxe.png) ![lunar-rescue](docs/images/lunar-rescue.png) ![balloon-bomber](docs/images/balloon-bomber.png)
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ These settings affect audio output. They can be changed if different audio sampl
 
 These settings are fixed to the specified rom.
 
-`roms:name` - The name of the rom. This is used as the name of the save state json file.<br>
+`roms:name` - The name of the rom. This is used as the name of the save state json file as well as the entries for the rom selection screen.<br>
 `roms:cpu:pc` - The meen cpu program counter. It **must** not be changed, doing so will yield undefined behaviour.<br>
 `roms:cpu:sp` - The meen cpu stack pointer. It **must** not be changed, doing so will yield undefined behaviour.<br>
 `memory:rom:scheme` - An optional parameter specifying the type of the rom resource to load, either `file://` or `json://`.<br>
@@ -277,7 +277,8 @@ These settings are fixed to the specified rom.
 `memory:rom:[block]:bytes`: The rom resource to load. When the resource is fully qualified it will ignore the scheme and directory parameters.
 `memory:rom:[block]:offset`: The offset into memory where the rom will be loaded, this value **must** not be changed, doing so will yield undefined behaviour.<br>
 
-**NOTE**: The rom name is used for the entry in the rom selection screen. It **must** not have any new line characters and **must** only contain characters defined in the supported font defined in `GlyphRenderer.cpp`. The maximum number of characters supported per entry is 26 ((the vram width (224) / the supported font width (8)) - 2 spaces (one is prepended and one is appeneded to the name)). 
+**NOTE**: The `roms:name` parameter **must** not contain any new line characters and **must** only contain characters defined in the supported font defined in `GlyphRenderer.cpp`. The maximum number of characters supported per entry is 26 ((the vram width (224) / the supported font width (8)) - 2 spaces (one is prepended and one is appeneded to the name)). 
+**NOTE**: When targetting the RP2040, the `memory:rom:[block]:bytes` parameter **can't** be changed.
 
 ### Desktop Keyboard Controls
 

--- a/conf/config.json
+++ b/conf/config.json
@@ -9,8 +9,8 @@
                 "saveAsync":true
             },
             "video": {
-                "width":224,
-                "height":256,
+                "width":320,
+                "height":240,
                 "fullScreen":false
             },
             "audio": {
@@ -23,7 +23,7 @@
             "video": {
                 "bpp":16,
                 "colour":"white",
-                "orientation":"upright"
+                "orientation":"cocktail"
             },
             "audio": {
                 "scheme":"file://",
@@ -49,7 +49,7 @@
             },
             "roms": [
                 {
-                    "name":"space-invaders",
+                    "name":"space invaders",
                     "cpu":{
                         "pc":0,
                         "sp":0
@@ -68,7 +68,7 @@
                     }
                 },
                 {
-                    "name":"space-invaders-deluxe",
+                    "name":"space invaders ii midway",
                     "cpu":{
                         "pc":0,
                         "sp":0
@@ -88,7 +88,7 @@
                     }
                 },
                 {
-                    "name":"space-invaders-ii",
+                    "name":"space invaders ii taito",
                     "cpu":{
                         "pc":0,
                         "sp":0
@@ -108,7 +108,7 @@
                     }
                 },
                 {
-                    "name":"balloon-bomber",
+                    "name":"balloon bomber",
                     "cpu":{
                         "pc":0,
                         "sp":0
@@ -128,7 +128,7 @@
                     }
                 },
                 {
-                    "name":"lunar-rescue",
+                    "name":"lunar rescue",
                     "cpu":{
                         "pc":0,
                         "sp":0

--- a/docs/README-bin.md
+++ b/docs/README-bin.md
@@ -52,8 +52,8 @@ The current settings for these options should be sufficient, changing them may h
 
 Video hardware options. These options can be changed for the desired output.
 
-`width:224` - The width of the screen. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
-`height:256` - The height of the screen. For non embedded platforms, the output will scale to fit. For embedded platforms, the value should be the width of your attached lcd panel<br>
+`width:320` - The width of the screen in pixels. For upright orientation, the minimum support width of the display is 240, for cocktail, 320.<br>
+`height:240` - The height of the screen in pixels. For upright orientation, the minimum supported height of the display is 320, for cocktail, 240.<br>
 `fullScreen:false` - Window or full screen display. (Experimental)<br>
 
 **NOTE**: the RP IO Controller does not support scaling or full-screen, the width and height parameters will be used to center the output on the display device.
@@ -77,9 +77,9 @@ These settings apply to the various arcade roms that can be loaded.
 
 These settings affect visual output and can be changed. They apply to all game roms loaded.
 
-`bpp:8` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
+`bpp:16` - Bits per pixel, supported values are 1 (experimental and not universally supported), 8 (rgb332) and 16 (rgb565).<br>
 `colour:white` - The forground colour (the background is always black), supported values are "white", "red", "green", "blue", "random" and a 16 bit custom hex value.<br>
-`orientation:upright` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
+`orientation:cocktail` - The window layout, "cocktail" for horizontal and "upright" for vertical.<br>
 
 **NOTE**: the RP IO Controller only supports cocktail orientation @ 16bpp.
 
@@ -105,10 +105,12 @@ These settings are fixed to the specified rom.
 `memory:rom:[block]:bytes`: The rom resource to load. When the resource is fully qualified it will ignore the scheme and directory parameters.
 `memory:rom:[block]:offset`: The offset into memory where the rom will be loaded, this value **must** not be changed, doing so will yield undefined behaviour.<br>
 
+**NOTE**: The rom name is used for the entry in the rom selection screen. It **must** not have any new line characters and **must** only contain characters defined in the supported font defined in `GlyphRenderer.cpp`. The maximum number of characters supported per entry is 26 ((the vram width (224) / the supported font width (8)) - 2 spaces (one is prepended and one is appeneded to the name)). 
+
 ### Desktop Keyboard Controls
 
-`q`: Quit<br>
-`c`: Credit<br>
+`q`: quit<br>
+`c`: credit<br>
 `1`: 1P<br>
 `2`: 2P<br>
 `a`: 1P left<br>
@@ -118,16 +120,18 @@ These settings are fixed to the specified rom.
 `4`: 4 ships<br>
 `5`: 5 ships<br>
 `6`: 6 ships<br>
-`t`: Tilt<br>
-`e`: Extra ship at<br>
+`t`: tilt<br>
+`e`: extra ship at<br>
 `j`: 2P left<br>
 `k`: 2P fire<br>
 `l`: 2P right<br>
-`i`: Show coin info<br>
-`y`: Save game<br>
-`r`: Load save game<br>
-`u`: Load from rom<br>
-`esc`: Return to the rom selection screen<br> 
+`i`: show coin info<br>
+`y`: save game<br>
+`r`: load save game<br>
+`up`: move to the prevous rom<br>
+`down`: move to the next rom<br>
+`enter`: load the selected rom<br>
+`esc`: return to the rom selection screen<br> 
 
 ### Embedded button controls
 
@@ -138,10 +142,10 @@ More buttons and/or logic can be added for a more complete emulation, 2 player s
 
 The pin layout used is the same as the [hardware lcd](https://www.waveshare.com/wiki/Pico-LCD-2) used for testing.
 
-`button 0`: when on the rom attraction screen, select the previous rom in the list of supported roms, when in gameplay mode, move the ship to the left.<br>
-`button 1`: when on the rom attraction screen, add a credit and start a single player game, when in gameplay mode, quit and return to the attraction screen.<br>
-`button 2`: when in gameplay mode, fire at the enemy.<br>
-`button 3`: when on the rom attraction screen, select the next rom in the list of supported roms, when in gameplay mode, move the ship to the right.<br>
+`button 0`: when on the loaded roms attraction screen, start a 1P game, when in gameplay mode, move the ship to the left.
+`button 1`: when in gameplay mode, quit and return to the rom selection screen.
+`button 2`: when on the rom selection screen, select the previous rom in the list of supported roms, when in gameplay mode, fire at the enemy.
+`button 3`: when on the rom selection screen, select the next rom in the list of supported roms, when in gameplay mode, move the ship to the right.
 
 ![space-invaders](docs/images/space-invaders.png) ![space-invaders-deluxe](docs/images/space-invaders-deluxe.png) ![lunar-rescue](docs/images/lunar-rescue.png) ![balloon-bomber](docs/images/balloon-bomber.png)
 

--- a/include/i8080_arcade/GlyphRenderer.h
+++ b/include/i8080_arcade/GlyphRenderer.h
@@ -116,13 +116,21 @@ namespace i8080_arcade
             */
             std::error_code SetJustification (Justification justification);
 
-            /** The blittable text
+            /** The blittable text (std::string_view overload)
 
                 Set the text that will be rendered when the Blit method is called.
 
                 @param  text            The text to render.
             */
             void SetText(std::string_view text);
+
+            /** The blittable text (std::string&& overload)
+
+                Set the text that will be rendered when the Blit method is called.
+
+                @param  text            The text to render.
+            */
+            void SetText(std::string&& text);
 
             /** Glyph lines height
 
@@ -180,6 +188,8 @@ namespace i8080_arcade
                 @remark                         The SetFont method needs to be called with a valid GlyphRenerer::Font, otherwise this method does nothing.
                 @remark                         Unknown font glyphs print a space (clear to black (or white if inversion is enabled)).
                 @remark                         The method GetMaxWidth can be used to obtain to total number of lines of glyphs.
+                @remark                         The parameters invertLineCount and invertLineStart refer to lines of text that have printable glyphs, ie,
+                                                new lines are ignored.
             */
             std::error_code Blit(std::vector<uint8_t>::iterator start, std::vector<uint8_t>::iterator end, int invertLineCount = 0, int invertLineStart = 0) const;
 

--- a/include/i8080_arcade/IIoController.h
+++ b/include/i8080_arcade/IIoController.h
@@ -89,14 +89,12 @@ namespace i8080_arcade
 		virtual std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int frameWidth, int frameHeight) = 0;
 
 		/** Load the selected rom or the save state of the currently selected rom
-			
-			@param	maxSize			The total number of roms in the rom list	
 
 			@return					A tuple holding two values:
 									bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.
 									int - the index into the roms array for the rom to be loaded or saved
 		*/
-		virtual std::tuple<bool, int> GetRomIndex(int maxSize) = 0;
+		virtual std::tuple<bool, int> GetRomIndex() = 0;
 
         /** Free any use resources
             

--- a/include/i8080_arcade/MemoryController.h
+++ b/include/i8080_arcade/MemoryController.h
@@ -77,13 +77,13 @@ namespace i8080_arcade
             ram frame pool for single/double/triple buffered video frames for
             optimised rendering.
 
-            @param      framePoolSize       The amount frames to allocate, each frame will be width * height bytes in length.
+            @param      framePoolSize       The number of frames to allocate, each frame will be framWidth * frameHeight bytes in length.
 
             @remark     default frame pool size is 1.
 
             @see framePool_
         */
-        MemoryController(int framePoolSize = 1);
+        MemoryController(const std::vector<std::pair<std::string, std::string>>& jsonRoms, int framePoolSize = 1);
 
         /** Destructor
 
@@ -95,15 +95,18 @@ namespace i8080_arcade
 
             The VideoFrame containing the current video ram is taken from a finite frame pool.
 
-            @param  screen  The screen to render.
-
-            @return         The current video ram as a recyclable resource.
-
-            @todo           The screen parameter needs to be the Screen enum defined in IIOController.h.
-                            Its definition needs to be moved to something like Types.h and the header
-                            needs to be included in this file.
+            @return             The current video ram as a recyclable resource.
         */
-        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetVideoFrame(int screen) const;
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetGameplayFrame() const;
+
+        /** Generate the current rom select screen
+        
+            The rom select screen lists the rom names defined in the config file that are available to load.
+
+            @param  romIndex    The rom index into the rom names to be rendered that will be highlighted as the currently
+                                selected rom.
+        */
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetRomSelectFrame(int romIndex) const;
 
         /** Clear the memory
 
@@ -195,8 +198,7 @@ namespace i8080_arcade
         */
         meen_hw::MH_ResourcePool<std::vector<uint8_t>> framePool_;
 
-        /**
-            Glyph renderer
+        /** Glyph renderer
 
             See GlyphRenderer.h for further details.
         */

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -167,6 +167,28 @@ namespace i8080_arcade
         bool lastK2_{};
         bool lastK3_{};
 
+        /** The currently selected rom
+			
+            When the user presses the up and down arrows, this will keep track
+            of the current index.
+				
+            Made atomic since it can be accesssed from a different thread if the runAsync config option
+            is set to true.
+        */
+        int romIndex_{};
+
+        /** The total number of supported roms for this controller.
+			
+            The value is the max limit used by the romIndex parameter to keep
+            itself within range.
+        */        
+        int romCount_{};
+
+        /** The running state
+
+            True if meen is to run on core 1, false to run on core 0 with
+            the main application.
+        */
         bool runAsync_{};
 
         /** The current screen
@@ -219,11 +241,12 @@ namespace i8080_arcade
             Creates an RP2040 specific i8080 arcade IO controller.
 
             @param		runAsync		Run this io controller asynchronously.
+            @param		romCount		The number of supported roms.
             @param		audioHardware	audio hardware configuration options.
             @param		videoHardware	video hardware configuration options.
 
         */
-        RPIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
+        RPIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
 
         /** Destructor
 
@@ -312,13 +335,11 @@ namespace i8080_arcade
 
         /** Load the selected rom or the save state of the currently selected rom
 
-        @param    maxSize            The total number of roms in the rom list
-
-        @return                      A tuple holding two values:
-                                     bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.
-                                     int - the index into the roms array for the rom to be loaded or saved
+            @return                 A tuple holding two values:
+                                    bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.
+                                    int - the index into the roms array for the rom to be loaded or saved
         */
-        std::tuple<bool, int> GetRomIndex(int maxSize) final;
+        std::tuple<bool, int> GetRomIndex() final;
     };
 } // namespace i8080_arcade
 #endif // RPIOCONTROLLER_H

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -157,13 +157,34 @@ namespace i8080_arcade
 
 			/** Keep track of previous key presses to prevent repeat events from triggering
 
-				Key 'r' restores the currently loaded rom save state (if it exists)
-				Key 'u' loads the currently selected rom
-				Key 'y' save the currently selected roms state
+				key 'down' moves to the next rom.
+				Key 'r' restores the currently loaded rom save state (if it exists).
+				Key 'return' loads the currently selected rom.
+				Key 'up' moves to the previous rom.
+				Key 'y' save the currently selected roms state.
 			*/
+			Uint8 lastDown_{};
 			Uint8 lastR_{};
-			Uint8 lastU_{};
+			Uint8 lastReturn_{};
+			Uint8 lastUp_{};
 			Uint8 lastY_{};
+
+			/** The currently selected rom
+			
+				When the user presses the up and down arrows, this will keep track
+				of the current index.
+				
+				Made atomic since it can be accesssed from a different thread if the runAsync config option
+				is set to true.
+			*/
+			std::atomic_int romIndex_{};
+
+			/** The total number of supported roms for this controller.
+			
+				The value is the max limit used by the romIndex parameter to keep
+				itself within range.
+			*/
+			int romCount_{};
 
 			/** The running state
 
@@ -208,10 +229,11 @@ namespace i8080_arcade
 				Creates an SDL specific i8080 arcade IO controller.
 
 				@param		runAsync		Run this io controller asynchronously.
-				@param		audioHardware	audio hardware configuration options.
-				@param		videoHardware	video hardware configuration options.
+				@param		romCount		The number of supported roms.
+				@param		audioHardware	Audio hardware configuration options.
+				@param		videoHardware	Video hardware configuration options.
 			*/
-			SDLIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
+			SDLIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
 
 			/** Destructor
 
@@ -290,20 +312,20 @@ namespace i8080_arcade
 				Create the video texture that will be rendered to the screen.
 
 				@param	videoTextures	JSON object describing the video texture.
+				@param  textureWidth    The width of the videc texture in pixels.
+            	@param  textureHeight   The height of the video texture in pixels.
 
 				@return					An error in the form of a std::error_code.
 			*/
-			std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int frameWidth, int frameHeight) final;
+			std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int textureWidth, int textureHeight) final;
 
 			/** Load the selected rom or the save state of the currently selected rom
-
-				@param	maxSize			The total number of roms in the rom list
 
 				@return					A tuple holding two values:
 										bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.
 										int - the index into the roms array for the rom to be loaded or saved
 			*/
-			std::tuple<bool, int> GetRomIndex(int maxSize) final;
+			std::tuple<bool, int> GetRomIndex() final;
 	};
 } // namespace i8080_arcade
 

--- a/source/GlyphRenderer.cpp
+++ b/source/GlyphRenderer.cpp
@@ -130,6 +130,15 @@ namespace i8080_arcade
         }
     }
 
+    void GlyphRenderer::SetText(std::string&& text)
+    {
+        if (text.empty() == false)
+        {
+            text_ = std::move(text);
+            Configure();
+        }
+    }
+
     int GlyphRenderer::GetWidth() const
     {
         return maxTxtWidth_;
@@ -300,7 +309,7 @@ namespace i8080_arcade
                         errc = centreTxt(++centreTxtIndex);
                     }
 
-                    lineIndex += newLines;
+                    lineIndex++;
                     newLines = 0;
                 }
 

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -26,7 +26,7 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    MemoryController::MemoryController(int framePoolSize)
+    MemoryController::MemoryController(const std::vector<std::pair<std::string, std::string>>& jsonRoms, int framePoolSize)
     {
         memory_.resize(memorySize_, 0);
         framePool_ = meen_hw::MH_ResourcePool<std::vector<uint8_t>>();
@@ -35,38 +35,9 @@ namespace i8080_arcade
 
         for(int i = 0; i < framePoolSize; i++)
         {
-            framePool_.AddResource(new std::vector<uint8_t>(frameWidth * frameHeight, 0));
-        }
+            auto frame = new std::vector<uint8_t>(frameWidth * frameHeight, 0);
 
-        auto setAnchorPoint = [this](bool setAnchorPoint)
-        {
-            if (setAnchorPoint == true)
-            {
-                // determine the offset at which to blit the text - we want to center the text on the surface
-                int widthOffset = (vramWidth_ - glyphRenderer_.GetWidth()) / 2;
-                int heightOffset = ((vramHeight_ - glyphRenderer_.GetHeight()) / 2) * frameWidth;
-                glyphRenderer_.SetAnchorPoint(centreOffset_ + widthOffset + heightOffset);
-            }
-        };
-
-        glyphRenderer_ = GlyphRenderer(frameWidth);
-        //glyphRenderer_.SetText("   BALLOON BOMBER   \n\n\n   LUNAR RESCUE   \n\n\n   TAITO   \n\n   SPACE INVADERS II   \n\n\n   MIDWAY   \n\n   SPACE INVADERS II   \n\n\n   SPACE INVADERS   ");
-        // todo: need to pass in the rom names from the config file in order to generated the render text
-        glyphRenderer_.SetText(" BALLOON BOMBER \n\n\n LUNAR RESCUE \n\n\n TAITO \n\n SPACE INVADERS II \n\n\n MIDWAY \n\n SPACE INVADERS II \n\n\n SPACE INVADERS ");
-        glyphRenderer_.SetJustification(GlyphRenderer::Justification::Centre);
-        glyphRenderer_.SetFont(GlyphRenderer::Font::I8080ArcadeRegular8x8);
-        setAnchorPoint(true);
-        //setAnchorPoint(!!glyphRenderer_.Update(">>"));
-        //setAnchorPoint(!!glyphRenderer_.Update("<<", 18));
-    }
-
-    meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MemoryController::GetVideoFrame(int screen) const
-    {
-        auto frame = framePool_.GetResource();
-
-        if(frame != nullptr)
-        {
-            // Thos dpes not take into account bounds checks ... negative values here will result in ub
+            // This does not take into account bounds checks ... negative values here will result in ub
             auto blitBorder = [frameBegin = frame->begin()](int x0Start, int x1Start, int width, int y0Start, int y1Start, int height, int lpm, int rpm)
             {
                 auto p1 = frameBegin + x1Start;
@@ -94,35 +65,76 @@ namespace i8080_arcade
             // blit a border around the vram
             blitBorder(centreOffset_ - frameWidth, centreOffset_ + (vramHeight_ * frameWidth), vramWidth_, centreOffset_ - frameWidth - 1, centreOffset_ + vramWidth_ - frameWidth, vramHeight_ + 10, 0x80, 0x01);
 
-            if (screen == 1 /* Screen::Gameplay */)
-            {
-                if (vramWidth_ == frameWidth)
-                {
-                    std::ranges::copy_n(memory_.begin() + vramOffset_, vramSize_, frame->begin());
-                }
-                else
-                {
-                    auto it = frame->begin() + centreOffset_;
-                    //auto vramStart = memory_.begin() + vramOffset_;
+            framePool_.AddResource(frame);
+        }
 
-                    for (auto vram = memory_.cbegin() + vramOffset_; vram < memory_.cbegin() + vramOffset_ + vramSize_; std::advance(vram, vramWidth_), std::advance(it, frameWidth))
-                    {
-                        std::ranges::copy_n(vram, vramWidth_, it);
-                    }
-                }
+        auto setAnchorPoint = [this](bool setAnchorPoint)
+        {
+            if (setAnchorPoint == true)
+            {
+                // determine the offset at which to blit the text - we want to center the text on the surface
+                int widthOffset = (vramWidth_ - glyphRenderer_.GetWidth()) / 2;
+                int heightOffset = ((vramHeight_ - glyphRenderer_.GetHeight()) / 2) * frameWidth;
+                glyphRenderer_.SetAnchorPoint(centreOffset_ + widthOffset + heightOffset);
+            }
+        };
+
+        std::string txtToBlit;
+
+        for (auto& jsonRom : jsonRoms)
+        {
+            txtToBlit += " " + jsonRom.first + " \n\n\n";
+        }
+
+        std::transform(txtToBlit.begin(), txtToBlit.end(), txtToBlit.begin(), ::toupper);
+        txtToBlit.erase(txtToBlit.end() - 3, txtToBlit.end());
+
+        glyphRenderer_ = GlyphRenderer(frameWidth);
+        glyphRenderer_.SetText(std::move(txtToBlit));
+        glyphRenderer_.SetJustification(GlyphRenderer::Justification::Centre);
+        glyphRenderer_.SetFont(GlyphRenderer::Font::I8080ArcadeRegular8x8);
+        setAnchorPoint(true);
+        //setAnchorPoint(!!glyphRenderer_.Update(">>"));
+        //setAnchorPoint(!!glyphRenderer_.Update("<<", 18));
+    }
+
+    meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MemoryController::GetRomSelectFrame(int romIndex) const
+    {
+        auto frame = framePool_.GetResource();
+
+        if (frame != nullptr)
+        {
+            // rom selection
+            auto errc = glyphRenderer_.Blit(frame->begin(), frame->end(), 1 /* invert one line */, romIndex /* starting at the rom index */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
+
+            if (errc)
+            {
+                printf("Failed to blit text: %s\n", errc.message().c_str());
+            }
+        }
+
+        return frame;
+    }
+    
+    meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MemoryController::GetGameplayFrame() const
+    {
+        auto frame = framePool_.GetResource();
+
+        if(frame != nullptr)
+        {
+            if (vramWidth_ == frameWidth)
+            {
+                std::ranges::copy_n(memory_.begin() + vramOffset_, vramWidth_ * vramHeight_, frame->begin() + centreOffset_);
             }
             else
             {
-                // rom selection
-                auto errc = glyphRenderer_.Blit(frame->begin(), frame->end(), 0 /* invert one line */, 16 /* starting at line 16 */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
+                auto it = frame->begin() + centreOffset_;
 
-                if (errc)
+                for (auto vram = memory_.cbegin() + vramOffset_; vram < memory_.cbegin() + vramOffset_ + vramSize_; std::advance(vram, vramWidth_), std::advance(it, frameWidth))
                 {
-                    printf("Failed to blit text: %s\n", errc.message().c_str());
+                    std::ranges::copy_n(vram, vramWidth_, it);
                 }
             }
-
-            // blit additional metadata here
         }
 
         return frame;

--- a/source/RPConfig.S
+++ b/source/RPConfig.S
@@ -1,9 +1,11 @@
 .section .rodata
+
 .global rpConfigStart
 rpConfigStart:
 .incbin "config.json"
 .global rpConfigEnd
 rpConfigEnd:
+
 .global invadersHStart
 invadersHStart:
 .incbin "invaders-h.bin"
@@ -24,3 +26,112 @@ invadersEStart:
 .incbin "invaders-e.bin"
 .global invadersEEnd
 invadersEEnd:
+
+.global invdeluxHStart
+invdeluxHStart:
+.incbin "invdelux-h.bin"
+.global invdeluxHEnd
+invdeluxHEnd:
+.global invdeluxGStart
+invdeluxGStart:
+.incbin "invdelux-g.bin"
+.global invdeluxGEnd
+invdeluxGEnd:
+.global invdeluxFStart
+invdeluxFStart:
+.incbin "invdelux-f.bin"
+.global invdeluxFEnd
+invdeluxFEnd:
+.global invdeluxEStart
+invdeluxEStart:
+.incbin "invdelux-e.bin"
+.global invdeluxEEnd
+invdeluxEEnd:
+.global invdeluxDStart
+invdeluxDStart:
+.incbin "invdelux-d.bin"
+.global invdeluxDEnd
+invdeluxDEnd:
+
+.global pv01Start
+pv01Start:
+.incbin "PV.01"
+.global pv01End
+pv01End:
+.global pv02Start
+pv02Start:
+.incbin "PV.02"
+.global pv02End
+pv02End:
+.global pv03Start
+pv03Start:
+.incbin "PV.03"
+.global pv03End
+pv03End:
+.global pv04Start
+pv04Start:
+.incbin "PV.04"
+.global pv04End
+pv04End:
+.global pv05Start
+pv05Start:
+.incbin "PV.05"
+.global pv05End
+pv05End:
+
+.global tn01Start
+tn01Start:
+.incbin "tn01.bin"
+.global tn01End
+tn01End:
+.global tn02Start
+tn02Start:
+.incbin "tn02.bin"
+.global tn02End
+tn02End:
+.global tn03Start
+tn03Start:
+.incbin "tn03.bin"
+.global tn03End
+tn03End:
+.global tn04Start
+tn04Start:
+.incbin "tn04.bin"
+.global tn04End
+tn04End:
+.global tn05Start
+tn05Start:
+.incbin "tn05-1.bin"
+.global tn05End
+tn05End:
+
+.global lrescue1Start
+lrescue1Start:
+.incbin "lrescue-1.bin"
+.global lrescue1End
+lrescue1End:
+.global lrescue2Start
+lrescue2Start:
+.incbin "lrescue-2.bin"
+.global lrescue2End
+lrescue2End:
+.global lrescue3Start
+lrescue3Start:
+.incbin "lrescue-3.bin"
+.global lrescue3End
+lrescue3End:
+.global lrescue4Start
+lrescue4Start:
+.incbin "lrescue-4.bin"
+.global lrescue4End
+lrescue4End:
+.global lrescue5Start
+lrescue5Start:
+.incbin "lrescue-5.bin"
+.global lrescue5End
+lrescue5End:
+.global lrescue6Start
+lrescue6Start:
+.incbin "lrescue-6.bin"
+.global lrescue6End
+lrescue6End:

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -352,14 +352,14 @@ namespace i8080_arcade
 
                     if (ButtonPress (!gpio_get(Pin::K2), lastK2_)) // we may need to set a callbcak on the pin since the press could be missed
                     {
-                        romIndex_ = ++romIndex % romCount_;
+                        romIndex_ = ++romIndex_ % romCount_;
                     }
 
                     if (ButtonPress (!gpio_get(Pin::K3), lastK3_)) // we may need to set a callbcak on the pin since the press could be missed
                     {                    
-                        if (--romIndex < 0)
+                        if (--romIndex_ < 0)
                         {
-                            romIndex = romCount_ - 1;
+                            romIndex_ = romCount_ - 1;
                         }
                     }
                 }

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -33,8 +33,10 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    RPIoController::RPIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
+    RPIoController::RPIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
         : runAsync_{ runAsync }
+		, romCount_{ romCount }
+		, romIndex_{ romCount - 1 }
     {
         i8080ArcadeIO_ = meen_hw::MakeI8080ArcadeIO();
 
@@ -340,12 +342,25 @@ namespace i8080_arcade
             {
                 if (screen_ == Screen::RomSelect)
                 {
-                    // Check button 2 press to trigger a rom load interrupt
-                    if (ButtonPress (!gpio_get(Pin::K2), lastK2_)) // we may need to set a callbcak on the pin since the press could be missed
+                    // Check button 1 press to trigger a rom load interrupt
+                    if (ButtonPress (!gpio_get(Pin::K1), lastK1_)) // we may need to set a callbcak on the pin since the press could be missed
                     {
                         isr = meen::ISR::Load;
                         screen_ = Screen::Gameplay;
                         ships_ = 0;
+                    }
+
+                    if (ButtonPress (!gpio_get(Pin::K2), lastK2_)) // we may need to set a callbcak on the pin since the press could be missed
+                    {
+                        romIndex_ = ++romIndex % romCount_;
+                    }
+
+                    if (ButtonPress (!gpio_get(Pin::K3), lastK3_)) // we may need to set a callbcak on the pin since the press could be missed
+                    {                    
+                        if (--romIndex < 0)
+                        {
+                            romIndex = romCount_ - 1;
+                        }
                     }
                 }
                 break;
@@ -362,7 +377,17 @@ namespace i8080_arcade
 
                 if (success == true)
                 {
-                    vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetVideoFrame(screen_);
+                    switch (screen_)
+                    {
+                        case Screen::RomSelect:
+                            vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetRomSelectFrame(romIndex_);
+                            break;
+                        case Screen::Gameplay:
+                            vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetGameplayFrame();
+                            break;
+                        default:
+                            printf ("Invalid screen\n");
+                    }
 
                     if(vfw->videoFrame != nullptr)
                     {
@@ -562,8 +587,8 @@ namespace i8080_arcade
         printf("%s\n", errorMsg.c_str());
     }
 
-    std::tuple<bool, int> RPIoController::GetRomIndex(int maxSize)
+    std::tuple<bool, int> RPIoController::GetRomIndex()
     {
-        return std::tuple(false, 0);
+        return std::tuple(false, romIndex_);
     }
 } // namespace i8080_arcade

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -30,8 +30,10 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    SDLIoController::SDLIoController(bool runAsync, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
+    SDLIoController::SDLIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
 		: runAsync_{ runAsync }
+		, romCount_{ romCount }
+		, romIndex_{ romCount - 1 }
 	{
 		SDL_SetMainReady();
 
@@ -126,9 +128,9 @@ namespace i8080_arcade
 		SDL_Quit();
 	}
 
-	std::tuple<bool, int> SDLIoController::GetRomIndex(int maxSize)
+	std::tuple<bool, int> SDLIoController::GetRomIndex()
 	{
-		return std::tuple(loadSaveState_.exchange(false), 0);
+		return std::tuple(loadSaveState_.exchange(false), romIndex_.load());
 	}
 
 	std::error_code SDLIoController::LoadAudioSamples(const JsonVariantConst audio)
@@ -406,17 +408,38 @@ namespace i8080_arcade
 			{
 				isr = loadSaveInterrupt_.exchange(meen::ISR::NoInterrupt);
 
-				if (isr == meen::ISR::Load && screen_ == Screen::RomSelect)
+				if (isr == meen::ISR::Load)
 				{
-					if (loadSaveState_ == false)
+					if (screen_ == Screen::RomSelect)
 					{
-						// We are loading a rom, move to the game play screen
-						screen_ = Screen::Gameplay;
+						// We are attempting to load from a rom and not a save file
+						if (loadSaveState_ == false)
+						{
+							// We are loading a rom, move to the game play screen
+							screen_ = Screen::Gameplay;
+						}
+						else
+						{
+							// We don't load state from the rom select screen, drop the interrupt
+							isr = meen::ISR::NoInterrupt;
+						}
+					}
+					else
+					{
+						// We can only load a save state from gameplay (as opposed to a rom), drop the interrupt
+						if (loadSaveState_ == false)
+						{
+							isr = meen::ISR::NoInterrupt;
+						}
 					}
 				}
-				else if (loadSaveState_ == false)
+				else if (isr == meen::ISR::Save)
 				{
-					isr = meen::ISR::NoInterrupt;
+					// We can't save anything from rom select, drop the interrupt
+					if (screen_ == Screen::RomSelect)
+					{
+						isr = meen::ISR::NoInterrupt;
+					}
 				}
 				break;
 			}
@@ -441,7 +464,20 @@ namespace i8080_arcade
 
 				if(videoFrameWrapper != nullptr)
 				{
-					videoFrameWrapper->videoFrame = static_cast<MemoryController*>(memoryController)->GetVideoFrame(screen_);
+					auto mc = static_cast<MemoryController*>(memoryController);
+
+					switch (screen_)
+					{
+						case Screen::RomSelect:
+							videoFrameWrapper->videoFrame = mc->GetRomSelectFrame(romIndex_);
+							break;
+						case Screen::Gameplay:
+							videoFrameWrapper->videoFrame = mc->GetGameplayFrame();
+							break;
+						default:
+							printf("Invalid screen\n");
+							break;
+					}
 				}
 
 				SDL_Event e{};
@@ -563,12 +599,33 @@ namespace i8080_arcade
 
 								SDL_RenderCopy(renderer_, texture_, nullptr, &dstRect_);
 								SDL_RenderPresent(renderer_);
+								
+								auto scrollIndex = [this](Uint8 key, Uint8 lastKey, int dir)
+								{
+									if (key ^ lastKey && key)
+									{
+										int romIndex = romIndex_;
 
+										romIndex = (romIndex + dir) % romCount_;
+
+										if (romIndex < 0)
+										{
+											romIndex = romCount_ - 1;
+										}
+
+										romIndex_ = romIndex;
+									}
+
+									return key;
+								};
+
+								lastUp_ = scrollIndex(state[SDL_SCANCODE_UP], lastUp_, 1);
+								lastDown_ = scrollIndex(state[SDL_SCANCODE_DOWN], lastDown_, -1);
 								// Check to see if the user wants to load a rom.
 								// This will only be acknowledged in ServiceInterrupts if screen_ is RomSelect,
 								// we could check screen_ for RomSelect here, but that would mean select_ would have
 								// to be atomic.
-								lastU_ = SetInterrupt(state[SDL_SCANCODE_U], lastU_, meen::ISR::Load, false);
+								lastReturn_ = SetInterrupt(state[SDL_SCANCODE_RETURN], lastReturn_, meen::ISR::Load, false);
 								break;
 							}
 							case EventCode::RenderAudio:

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -50,6 +50,52 @@ extern uint8_t invadersFEnd;
 extern uint8_t invadersEStart;
 extern uint8_t invadersEEnd;
 
+extern uint8_t invdeluxHStart;
+extern uint8_t invdeluxHEnd;
+extern uint8_t invdeluxGStart;
+extern uint8_t invdeluxGEnd;
+extern uint8_t invdeluxFStart;
+extern uint8_t invdeluxFEnd;
+extern uint8_t invdeluxEStart;
+extern uint8_t invdeluxEEnd;
+extern uint8_t invdeluxDStart;
+extern uint8_t invdeluxDEnd;
+
+extern uint8_t pv01Start;
+extern uint8_t pv01End;
+extern uint8_t pv02Start;
+extern uint8_t pv02End;
+extern uint8_t pv03Start;
+extern uint8_t pv03End;
+extern uint8_t pv04Start;
+extern uint8_t pv04End;
+extern uint8_t pv05Start;
+extern uint8_t pv05End;
+
+extern uint8_t tn01Start;
+extern uint8_t tn01End;
+extern uint8_t tn02Start;
+extern uint8_t tn02End;
+extern uint8_t tn03Start;
+extern uint8_t tn03End;
+extern uint8_t tn04Start;
+extern uint8_t tn04End;
+extern uint8_t tn05Start;
+extern uint8_t tn05End;
+
+extern uint8_t lrescue1Start;
+extern uint8_t lrescue1End;
+extern uint8_t lrescue2Start;
+extern uint8_t lrescue2End;
+extern uint8_t lrescue3Start;
+extern uint8_t lrescue3End;
+extern uint8_t lrescue4Start;
+extern uint8_t lrescue4End;
+extern uint8_t lrescue5Start;
+extern uint8_t lrescue5End;
+extern uint8_t lrescue6Start;
+extern uint8_t lrescue6End;
+
 extern char rpConfigStart;
 extern char rpConfigEnd;
 #else
@@ -113,7 +159,11 @@ int main(int argc, char** argv)
 
 		const std::unordered_map<std::string_view, std::pair<uintptr_t, uint16_t>> romNameToAddr
 		{
-			{ "invaders-e.bin", toPair(&invadersEStart, &invadersEEnd) }, { "invaders-f.bin", toPair(&invadersFStart, &invadersFEnd) }, { "invaders-g.bin", toPair(&invadersGStart, &invadersGEnd) }, { "invaders-h.bin", toPair(&invadersHStart, &invadersHEnd) }
+			{ "invaders-e.bin", toPair(&invadersEStart, &invadersEEnd) }, { "invaders-f.bin", toPair(&invadersFStart, &invadersFEnd) }, { "invaders-g.bin", toPair(&invadersGStart, &invadersGEnd) }, { "invaders-h.bin", toPair(&invadersHStart, &invadersHEnd) },
+			{ "invdelux-d.bin", toPair(&invdeluxDStart, &invdeluxDEnd) }, { "invdelux-e.bin", toPair(&invdeluxEStart, &invdeluxEEnd) }, { "invdelux-f.bin", toPair(&invdeluxFStart, &invdeluxFEnd) }, { "invdelux-g.bin", toPair(&invdeluxGStart, &invdeluxGEnd) }, { "invdelux-h.bin", toPair(&invdeluxHStart, &invdeluxHEnd) },
+			{ "PV.01", toPair(&pv01Start, &pv01End) }, { "PV.02", toPair(&pv02Start, &pv02End) }, { "PV.03", toPair(&pv03Start, &pv03End) }, { "PV.04", toPair(&pv04Start, &pv04End) }, { "PV.05", toPair(&pv05Start, &pv05End) },
+			{ "tn01.bin", toPair(&tn01Start, &tn01End) }, { "tn02.bin", toPair(&tn02Start, &tn02End) }, { "tn03.bin", toPair(&tn03Start, &tn03End) }, { "tn04.bin", toPair(&tn04Start, &tn04End) }, { "tn05-1.bin", toPair(&tn05Start, &tn05End) },
+			{ "lrescue-1.bin", toPair(&lrescue1Start, &lrescue1End) }, { "lrescue-2.bin", toPair(&lrescue2Start, &lrescue2End) }, { "lrescue-3.bin", toPair(&lrescue3Start, &lrescue3End) }, { "lrescue-4.bin", toPair(&lrescue4Start, &lrescue4End) }, { "lrescue-5.bin", toPair(&lrescue5Start, &lrescue5End) }, { "lrescue-6.bin", toPair(&lrescue6Start, &lrescue6End) }
 		};
 
 		stdio_init_all();
@@ -142,7 +192,6 @@ int main(int argc, char** argv)
 			CHECK_ERROR(!r["memory"], printf("No memory found in config file rom\n"));
 			CHECK_ERROR(!r["memory"]["rom"], printf("No rom found in config file memory\n"));
 			CHECK_ERROR(!r["memory"]["rom"]["block"], printf("No rom block found in config file memory\n"));
-
 // For baremetal platforms we need to update the config file so it loads from flash rather than a file
 #ifdef ENABLE_MH_RP2040
 			auto&& rom = r["memory"]["rom"];
@@ -154,8 +203,11 @@ int main(int argc, char** argv)
 				// Check the names of the roms and set the correct rom address accordingly
 				auto name = block["bytes"].as<std::string_view>();
 				CHECK_ERROR(!romNameToAddr.contains(name), printf("The memory rom block is missing bytes: %s\n", std::string(name).c_str()));
-				block["bytes"] = std::to_string(romNameToAddr.at(name).first);
+
+				// The size parameter must be set before bytes as name is a string_view.
+				// Reversing the order would cause ub as the view would be looking at the address rather than the name.
 				block["size"] = romNameToAddr.at(name).second;
+				block["bytes"] = std::to_string(romNameToAddr.at(name).first);
 			}
 #endif // ENABLE_MH_RP2040
 			// Cache all rom strings in a vector of pairs with first being the rom name

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -70,25 +70,25 @@ if(value)\
 #include "i8080_arcade/SdlIoController.h"
 #endif // ENABLE_MH_RP2040
 
-static i8080_arcade::MemoryController* MakeMemoryController()
+static i8080_arcade::MemoryController* MakeMemoryController(const std::vector<std::pair<std::string, std::string>>&jsonRoms)
 {
 #ifdef ENABLE_MH_RP2040
-	return new i8080_arcade::MemoryController(3); // 3 - Three frame for triple buffered rendering
+	return new i8080_arcade::MemoryController(jsonRoms, 3); // 3 - Three frame for triple buffered rendering
 #else
-	return new i8080_arcade::MemoryController();
+	return new i8080_arcade::MemoryController(jsonRoms);
 #endif
 }
 
-static i8080_arcade::IIoController* MakeIoController(bool runAsync, JsonVariantConst audioHardware, JsonVariantConst videoHardware)
+static i8080_arcade::IIoController* MakeIoController(bool runAsync, int romCount, JsonVariantConst audioHardware, JsonVariantConst videoHardware)
 {
 	if (!audioHardware|| !videoHardware)
 	{
 		return nullptr;
 	}
 #ifdef ENABLE_MH_RP2040
-	return new i8080_arcade::RPIoController(runAsync, audioHardware, videoHardware);
+	return new i8080_arcade::RPIoController(runAsync, romCount, audioHardware, videoHardware);
 #else
-	return new i8080_arcade::SDLIoController(runAsync, audioHardware, videoHardware);
+	return new i8080_arcade::SDLIoController(runAsync, romCount, audioHardware, videoHardware);
 #endif // ENABLE_MH_RP2040
 }
 
@@ -163,20 +163,17 @@ int main(int argc, char** argv)
 			std::string str;
 			serializeJson(r, str);
 			jsonRoms.emplace_back (r["name"].as<std::string>(), std::move(str));
-
-			// remove this once support for all other roms has been added
-			break;
 		}
 
 		auto meen = hardware["meen"];
 		CHECK_ERROR(!meen, printf("Invalid json config file format: meen section not found\n"));
 
 		// Create our custom i8080 arcade I/O controller based on a specific configuration.
-		auto ioController = MakeIoController(meen["runAsync"], hardware["audio"], hardware["video"]);
+		auto ioController = MakeIoController(meen["runAsync"], jsonRoms.size(), hardware["audio"], hardware["video"]);
 		CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
 
 		// Create our custom i8080 arcade memory controller.
-		auto memoryController = MakeMemoryController();
+		auto memoryController = MakeMemoryController(jsonRoms);
 		CHECK_ERROR(!memoryController, printf("Failed to create the memory controller\n"));
 
 		// Set up the custom controllers prior to configuring the machine.
@@ -233,7 +230,7 @@ int main(int argc, char** argv)
 				return meen::errc::invalid_argument;
 			}
 
-			auto [unused, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex(jsonRoms.size());
+			auto [unused, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex();
 			std::ofstream fout(saveFilePath + "/" + jsonRoms[romIndex].first + ".json", std::ios::trunc);
 
 			if (!fout.good())
@@ -248,7 +245,7 @@ int main(int argc, char** argv)
 		// Will be called from a different thread if the 'runAsync' or 'loadAsync' configuration options are set to true
 		machine->OnLoad([&jsonRoms, &saveFilePath](char* json, int* jsonLen, meen::IController* ioController)
 		{
-			auto [loadSaveState, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex(jsonRoms.size());
+			auto [loadSaveState, romIndex] = static_cast<i8080_arcade::IIoController*>(ioController)->GetRomIndex();
 
 			if (loadSaveState == true)
 			{


### PR DESCRIPTION
Supported roms can now be selected and loaded via the rom selection screen. See the README for further details.

-  Documentation updates.
- The config file is compatible with all supported platforms by default.
- There are loading issues with the RP2040 platform that require further investigation (future pr).
- The names of the roms can be changed in the config file which will be reflected on the rom selection screen (see the README for restrictions).
- The memory controller blits the screen types, the io controller controls what screen to blit.