### PR TITLE
#106 chore: remove cpu configuration

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -50,10 +50,6 @@
             "roms": [
                 {
                     "name":"space invaders",
-                    "cpu":{
-                        "pc":0,
-                        "sp":0
-                    },
                     "memory": {
                         "rom": {
                             "scheme":"file://",
@@ -69,10 +65,6 @@
                 },
                 {
                     "name":"space invaders ii midway",
-                    "cpu":{
-                        "pc":0,
-                        "sp":0
-                    },
                     "memory": {
                         "rom": {
                             "scheme":"file://",
@@ -89,10 +81,6 @@
                 },
                 {
                     "name":"space invaders ii taito",
-                    "cpu":{
-                        "pc":0,
-                        "sp":0
-                    },
                     "memory": {
                         "rom": {
                             "scheme":"file://",
@@ -109,10 +97,6 @@
                 },
                 {
                     "name":"balloon bomber",
-                    "cpu":{
-                        "pc":0,
-                        "sp":0
-                    },
                     "memory": {
                         "rom": {
                             "scheme":"file://",
@@ -129,10 +113,6 @@
                 },
                 {
                     "name":"lunar rescue",
-                    "cpu":{
-                        "pc":0,
-                        "sp":0
-                    },
                     "memory": {
                         "rom": {
                             "scheme":"file://",

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -367,7 +367,10 @@ namespace i8080_arcade
             }
             case 1:
             {
-                isr = meen::ISR::One;
+                if (screen_ == Screen::Gameplay)
+                {
+                    isr = meen::ISR::One;
+                }
                 break;
             }
             case 2:
@@ -412,7 +415,10 @@ namespace i8080_arcade
                     printf("1 Video frame dropped, renderer too slow\n");
                 }
 
-                isr = meen::ISR::Two;
+                if (screen_ == Screen::Gameplay)
+                {
+                    isr = meen::ISR::Two;
+                }
                 break;
             }
             default:


### PR DESCRIPTION
- Removed the cpu section in the roms portion of the configuration file, it is no longer needed.
- Don't return any interrupts when on the rom select screen.