### PR TITLE
#108 fix: event handling and frame rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Added rendered metadata `frame rate`, `time`
   `uptime` and `memory usage`.
 * Added rendered Midway/Taito copyright.
+* Refactored the event handling.
 
 0.6.1 [04/08/24]
 * Added profiles for improved build support.

--- a/include/i8080_arcade/MemoryController.h
+++ b/include/i8080_arcade/MemoryController.h
@@ -45,7 +45,7 @@ namespace i8080_arcade
         The title and credits are rendered to the top centre of the display.
         Additional metadata rendered to the center bottom of the display from left to right
         includes: current frame rate, current time (24hr), current up time (loops every hour)
-        and current physical ram usage (see GetMemoryUsage method for further details).
+        and current physical ram usage (see GetPhysicalMemoryUsage method for further details).
     */
     class MemoryController final : public meen::IController
     {
@@ -73,6 +73,18 @@ namespace i8080_arcade
                         of a callback of some sorts in which to render custom graphics to the surface.
         */
         static constexpr int frameHeight{ 240 };
+
+        /** The width of the vram
+
+            The 1bpp width in bytes of the vram that resides in memory.
+        */
+        static constexpr int vramWidth{ 32 };
+
+        /** The height of the vram
+
+            The vram that resides in memory in pixels.
+        */
+        static constexpr int vramHeight{ 224 };
 
         /** Constructor
 
@@ -106,7 +118,7 @@ namespace i8080_arcade
         meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetGameplayFrame(uint64_t currTime);
 
         /** Generate the current rom select screen
-        
+
             The rom select screen lists the rom names defined in the config file that are available to load.
 
             @param  romIndex    The rom index into the rom names to be rendered that will be highlighted as the currently
@@ -115,11 +127,25 @@ namespace i8080_arcade
         */
         meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr GetRomSelectFrame(int romIndex, uint64_t currTime);
 
-        /** Clear the memory
+        /** Clear all internal memory and frame buffers
 
-            Wipe the all the memory and frame pool frame buffers to 0.
+            All buffers will be set to 0x00.
+
+            @param    backBuffer    The current off screen buffer to clear.
         */
-        void Clear();
+        void Clear(std::vector<uint8_t>* backBuffer);
+
+        /** Populate the memory controller frame pool
+
+            This function MUST be called before attaching the controller to the machine.
+
+            @param    framePoolSize    The number of frames to allocate in the native pixel format with the specified
+                                       resolution.
+
+            @return                    The initial frame to render, this can then be used as the initial frame in a
+                                       double buffered system.
+        */
+        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MakeFramePool(int framePoolSize);
 
         /** Read from controller
 
@@ -161,23 +187,11 @@ namespace i8080_arcade
         //cppcheck-suppress unusedStructMember
         static constexpr size_t memorySize_{ 1 << 16 };
 
-        /** The width of the vram
-
-            The 1bpp width in bytes of the vram that resides in memory.
-        */
-        static constexpr int vramWidth_{ 32 };
-
-        /** The height of the vram
- 
-            The vram that resides in memory in pixels.
-        */
-        static constexpr int vramHeight_{ 224 };
-
         /** VRAM size
 
             The total size in bytes.
         */
-        static constexpr int vramSize_{ vramWidth_ * vramHeight_ };
+        static constexpr int vramSize_{ vramWidth * vramHeight };
 
         /** VRAM memory offset
 
@@ -189,7 +203,7 @@ namespace i8080_arcade
 
             The offset from the beginning of the frame at which to blit the vram so that it is blitted in the middle of the frame.
         */
-        static constexpr int centreOffset_{ (((frameHeight - vramHeight_) / 2) * frameWidth) + ((frameWidth - vramWidth_) / 2) };
+        static constexpr int centreOffset_{ (((frameHeight - vramHeight) / 2) * frameWidth) + ((frameWidth - vramWidth) / 2) };
 
         /** Memory buffer
 
@@ -243,7 +257,7 @@ namespace i8080_arcade
         int fps_{};
 
         /** The seconds portion of the current up time
-        
+
             @remark reset to 0 when it reaches 60.
         */
         uint8_t seconds_{};
@@ -266,13 +280,14 @@ namespace i8080_arcade
 
         /** Obtain the current ram usage for the application
 
-            The behaviour of this method varies depending on the platform it is running.
+            The behaviour of this method varies depending on the platform.
 
             @return     The total usage in kilobytes.
 
             @remark Under Windows it will return the total ram usage in the current woring set
             (as opposed to the private working set).
             @remark Under RP2040 it will return the total amount of the heap that has been used.
+            @remark Other supported platforms will return the /proc/self/stat resident set size when available.
         */
         static int GetPhysicalMemoryUsage();
     };

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -25,6 +25,7 @@ SOFTWARE.
 
 #include <ArduinoJson.h>
 #include <pico/util/queue.h>
+#include <variant>
 #include <vector>
 
 #include "i8080_arcade/IIoController.h"
@@ -91,8 +92,16 @@ namespace i8080_arcade
         */
         int heightOffset_{};
 
-        // The width/height of the memory controller frame buffers
+        /** The width of the attached lcd panel in pixels
+
+            @remark    using a different value other than the correct lcd width is untested.
+        */
         int textureWidth_{};
+
+        /** The height of the attached lcd panel in pixels
+
+            @remark    using a different value other than the correct lcd height is untested.
+        */
         int textureHeight_{};
 
         /** The previous video frame
@@ -113,32 +122,48 @@ namespace i8080_arcade
         */
         std::unique_ptr<meen_hw::MH_II8080ArcadeIO> i8080ArcadeIO_;
 
-        /** Video frame to render queue
+	    /** Helper type for functional style visitor for std::visit
 
-            A double element queue used to render the current frame while generating the next frame.
+	        This template helper type is taken straight from cppreference std::visit examples (https://en.cppreference.com/w/cpp/utility/variant/visit2)
+	    */
+	    template<class... Ts>
+	    struct overloaded : Ts... { using Ts::operator()...; };
+
+	    /** Generated event data
+
+            A using directve for ease of use. This will hold the active event data to be processed.
+
+            bool:        True to clear the vram area of the lcd display, false otherwise.
+            std::string: The application has encountered and error.
+            ResourcePtr: The next video frame is ready to be rendered. This event drives the control loop.
+	    */
+	    using EventData = std::variant<std::string, bool, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
+
+	    /** A finite EventData resource pool
+
+            A vector of EventData variants to be used during the event handleing process.
+
+            @remark    Populate from a fnite array of EventData objects
+	    */
+        queue_t eventDataQueue_;
+
+        /** Available event data queue
+
+            The pool of available events that can be filled.
         */
-        queue_t videoFrameQueue_;
+        queue_t eventDataFreeQueue_;
 
-        /** Available frame queue
+        /** The maximum number of events across all pools
 
-            Remainder frames (ones that are not being rendered or generated).
+            This can be increased/decreased depending on requirements.
         */
-        queue_t freeQueue_;
+        static constexpr int maxEventData_{ 2 };
 
-        /** VideoFrameWrapper
+        /** An array of EventData variants for use with RP2040s C based queue api
 
-            A convenience wrapper used to pass unique pointers through RP2040s C based queue api.
+            @remark    these wrappers are solely accessed via the event data queues.
         */
-        struct VideoFrameWrapper
-        {
-            meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr videoFrame;
-        };
-
-        /** An array of resourcePtr wrappers for use with RP2040s C based queue api
-
-            @remark    these wrappers are solely accessed via queues to implement double buffering.
-        */
-        VideoFrameWrapper videoFrameWrapper_[2];
+        EventData eventData_[maxEventData_];
 
         /** Video frame buffer
 
@@ -168,20 +193,20 @@ namespace i8080_arcade
         bool lastK3_{};
 
         /** The currently selected rom
-			
+
             When the user presses the up and down arrows, this will keep track
             of the current index.
-				
+
             Made atomic since it can be accesssed from a different thread if the runAsync config option
             is set to true.
         */
         int romIndex_{};
 
         /** The total number of supported roms for this controller.
-			
+
             The value is the max limit used by the romIndex parameter to keep
             itself within range.
-        */        
+        */
         int romCount_{};
 
         /** The running state
@@ -241,12 +266,13 @@ namespace i8080_arcade
             Creates an RP2040 specific i8080 arcade IO controller.
 
             @param		runAsync		Run this io controller asynchronously.
+            @param      backBuffer      The first frame to use for double buffering.
             @param		romCount		The number of supported roms.
             @param		audioHardware	audio hardware configuration options.
             @param		videoHardware	video hardware configuration options.
 
         */
-        RPIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
+        RPIoController(bool runAsync, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr&& backBuffer, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware);
 
         /** Destructor
 
@@ -295,31 +321,31 @@ namespace i8080_arcade
             Create the video texture that will be rendered to the screen.
 
             @param  videoTextures   JSON object describing the video texture.
-            @param  textureWidth    The width of the videc texture in pixels.
+            @param  textureWidth    The width of the video texture in pixels.
             @param  textureHeight   The height of the video texture in pixels.
 
-			@return					An error in the form of a std::error_code.
+            @return                 An error in the form of a std::error_code.
         */
         std::error_code LoadVideoTextures(const JsonVariantConst videoTextures, int textureWidth, int textureHeight) final;
 
-   		/** Load Audio Samples
+        /** Load Audio Samples
 
             Loads the audio samples from the configuration file.
 
-			@param	audioSamples	JSON object representing the audio sample files.
+            @param     audioSamples    JSON object representing the audio sample files.
 
-			@return					An error in the form of a std::error_code.
-		*/
+            @return    An error in the form of a std::error_code.
+        */
         std::error_code LoadAudioSamples(const JsonVariantConst audioSamples) final;
 
         /** Main control loop
 
             Process all incoming events.
 
-            @return                 True to quit the machine, false otherwise.
+            @return    True to quit the machine, false otherwise.
 
-            @remark                 This method will always return false, ie; the loop
-                                    will run until the device is switched off.
+            @remark    This method will always return false, ie; the loop
+                       will run until the device is switched off.
         */
         bool HandleEvent() final;
 
@@ -335,9 +361,9 @@ namespace i8080_arcade
 
         /** Load the selected rom or the save state of the currently selected rom
 
-            @return                 A tuple holding two values:
-                                    bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.
-                                    int - the index into the roms array for the rom to be loaded or saved
+            @return    A tuple holding two values:
+                       bool - only valid when loading roms, true if the save file is to be loaded, false if the rom is to be loaded.
+                       int - the index into the roms array for the rom to be loaded or saved
         */
         std::tuple<bool, int> GetRomIndex() final;
     };

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <atomic>
 #include <SDL.h>
 #include <SDL_mixer.h>
+#include <variant>
 #include <vector>
 
 #include "i8080_arcade/IIoController.h"
@@ -92,40 +93,39 @@ namespace i8080_arcade
 			*/
 			uint64_t siEvent_{};
 
-			/** SDL Event codes
+			/** Helper type for functional style visitor for std::visit
 
-				Individual event codes that can be set on an SDL_Event of type 'i8080 arcade Event'.
-
-				@see siEvent_
+				This template helper type is taken straight from cppreference std::visit examples (https://en.cppreference.com/w/cpp/utility/variant/visit2)
 			*/
-			enum EventCode
-			{
-				RenderVideo,	/**< The next video frame is ready to be rendered. This event drives the control loop */
-				RenderAudio,	/**< Audio is ready to be played. The siEvent data1 type is the index into the mixChunk_ to be played. */
-				ReadInput		/**< Check if there is any input from the user. The siEvent data1 type is the type of input to be checked. */
-			};
+			template<class... Ts>
+			struct overloaded : Ts... { using Ts::operator()...; };
 
-			/** VideoFrameWrapper
+			/** Generated event data
+			
+				A using directve for ease of use. This will hold the active event data to be processed.
+				
+				uint16_t:		Check if there is any input from the user. The SDL_Event data2 type is a promise to filled with the user input.
+				uint8_t:		Audio is ready to be played. The SDL_Event data2 type is the index into the mixChunk_ to be played.
+				std::string:	The application has encountered and error.
+				ResourcePtr:	The next video frame is ready to be rendered. This event drives the control loop.
 
-			 	A convenience wrapper used to pass unique pointers through SDL's event structure.
+				The EventData will be used for the SDL_Event data1 property.
 			*/
-			struct VideoFrameWrapper
-			{
-				meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr videoFrame;
-			};
+			using EventData = std::variant<std::string, uint8_t, uint16_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
+			
+			/** A finite EventData resource pool
+			
+				A vector of EventData variants to be used during the event handleing process.
 
-			/** videoFrameWrapperPool_
-
-				An array of frame wrappers used to pass video frames from the machine thread
-				to the main thread.
+				@remark		Set to a size of 2 (done as a resize in the constructor, todo: probably should be passed as a parameter to the constructor)
 			*/
-			std::vector<std::unique_ptr<VideoFrameWrapper>> videoFrameWrapperPool_;
+			std::vector<std::unique_ptr<EventData>> eventDataPool_;
 
-			/** videoFrameWrapperMutex_
+			/** Event data pool mutex
 
-				Video frame mutual exclusion between the main thread and the machine thread.
+				event data mutual exclusion between the main thread and the machine thread.
 			*/
-			std::mutex videoFrameWrapperMutex_;
+			std::mutex eventDataMutex_;
 
 			/** Prepare for shut down
 
@@ -223,6 +223,15 @@ namespace i8080_arcade
 			*/
 			Uint8 SetInterrupt(Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState);
 
+			/** Get event data from the event data pool
+			
+				Removes an EventData resource from the event data pool and returns it.
+
+				@return		An EventData variant pointer.
+
+				@remark		Once the event data has been use it MUST be returned to the event data pool.
+			*/
+			EventData* GetEventData();
 		public:
 			/** Initialisation constructor
 

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -101,9 +101,9 @@ namespace i8080_arcade
 			struct overloaded : Ts... { using Ts::operator()...; };
 
 			/** Generated event data
-			
+
 				A using directve for ease of use. This will hold the active event data to be processed.
-				
+
 				uint16_t:		Check if there is any input from the user. The SDL_Event data2 type is a promise to filled with the user input.
 				uint8_t:		Audio is ready to be played. The SDL_Event data2 type is the index into the mixChunk_ to be played.
 				std::string:	The application has encountered and error.
@@ -112,9 +112,9 @@ namespace i8080_arcade
 				The EventData will be used for the SDL_Event data1 property.
 			*/
 			using EventData = std::variant<std::string, uint8_t, uint16_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
-			
+
 			/** A finite EventData resource pool
-			
+
 				A vector of EventData variants to be used during the event handleing process.
 
 				@remark		Set to a size of 2 (done as a resize in the constructor, todo: probably should be passed as a parameter to the constructor)
@@ -170,17 +170,17 @@ namespace i8080_arcade
 			Uint8 lastY_{};
 
 			/** The currently selected rom
-			
+
 				When the user presses the up and down arrows, this will keep track
 				of the current index.
-				
+
 				Made atomic since it can be accesssed from a different thread if the runAsync config option
 				is set to true.
 			*/
 			std::atomic_int romIndex_{};
 
 			/** The total number of supported roms for this controller.
-			
+
 				The value is the max limit used by the romIndex parameter to keep
 				itself within range.
 			*/
@@ -224,7 +224,7 @@ namespace i8080_arcade
 			Uint8 SetInterrupt(Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState);
 
 			/** Get event data from the event data pool
-			
+
 				Removes an EventData resource from the event data pool and returns it.
 
 				@return		An EventData variant pointer.

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -94,8 +94,8 @@ namespace i8080_arcade
         romList_.SetText(std::move(txtToBlit));
         romList_.SetJustification(GlyphRenderer::Justification::Centre);
         // determine the offset at which to blit the text - we want to center the text on the surface
-        auto widthOffset = (vramWidth_ - romList_.GetWidth()) / 2;
-        auto heightOffset = ((vramHeight_ - romList_.GetHeight()) / 2) * frameWidth;
+        auto widthOffset = (vramWidth - romList_.GetWidth()) / 2;
+        auto heightOffset = ((vramHeight - romList_.GetHeight()) / 2) * frameWidth;
         romList_.SetAnchorPoint(centreOffset_ + widthOffset + heightOffset);
 
         char buf[64];// length of the metadata string rounded to the next power of 2
@@ -105,7 +105,7 @@ namespace i8080_arcade
         snprintf(buf, 64, "060 %02d:%02d:%02d %02d:%02d %06d\nFPS   TIME   UTIME MEMORY", tm->tm_hour, tm->tm_min, tm->tm_sec, minutes_, seconds_, GetPhysicalMemoryUsage());
         metadata_.SetText(std::string_view(buf, 51)); // 51 - the meximum length of the metadata string
         // Position the metadata at the bottom centre of screen
-        widthOffset = ((frameWidth - vramWidth_) / 4) - 1;
+        widthOffset = ((frameWidth - vramWidth) / 4) - 1;
         heightOffset = ((frameHeight - metadata_.GetHeight()) / 2) * frameWidth;
         metadata_.SetAnchorPoint(widthOffset + heightOffset);
 
@@ -113,62 +113,12 @@ namespace i8080_arcade
         credits_.SetText("COPYRIGHT:TAITO/MIDWAY\nMEEN I8080 ARCADE"sv);
         credits_.SetJustification(GlyphRenderer::Justification::Centre);
         // Position the credits at the top centre
-        widthOffset = vramWidth_ + ((frameWidth - vramWidth_) / 2) + 1;
+        widthOffset = vramWidth + ((frameWidth - vramWidth) / 2) + 1;
         heightOffset = ((frameHeight - credits_.GetHeight()) / 2) * frameWidth;
         credits_.SetAnchorPoint(widthOffset + heightOffset);
 
         memory_.resize(memorySize_, 0);
-        framePool_ = meen_hw::MH_ResourcePool<std::vector<uint8_t>>();
         static_assert((frameWidth * frameHeight) >= (vramSize_));
-
-        for(int i = 0; i < framePoolSize; i++)
-        {
-            auto frame = new std::vector<uint8_t>(frameWidth * frameHeight, 0);
-
-            // This does not take into account bounds checks ... negative values here will result in ub
-            auto blitBorder = [frameBegin = frame->begin()](int x0Start, int x1Start, int width, int y0Start, int y1Start, int height, int lpm, int rpm)
-            {
-                auto p1 = frameBegin + x1Start;
-
-                for (auto p0 = frameBegin + x0Start; p0 < frameBegin + x0Start + width; std::advance(p0, 1), std::advance(p1, 1))
-                {
-                    *p0 = *p1 = 0xFF;
-                }
-
-                p1 = frameBegin + y1Start;
-
-                for (auto p0 = frameBegin + y0Start; p0 < frameBegin + ((height - 1) * frameWidth); std::advance(p0, frameWidth), std::advance(p1, frameWidth))
-                {
-                    *p0 = lpm & 0xFF;
-                    *p1 = rpm & 0xFF;
-
-                    // This will keep the remaining pixels in the frame buffer
-                    // *p0 |= lpm;
-                    // *p1 |= rpm;
-                }
-            };
-
-            // blit a border around the surface
-            blitBorder(0, frame->size() - frameWidth, frameWidth, frameWidth, frameWidth * 2 - 1, frameHeight, 0x01, 0x80);
-            // blit a border around the vram
-            blitBorder(centreOffset_ - frameWidth, centreOffset_ + (vramHeight_ * frameWidth), vramWidth_, centreOffset_ - frameWidth - 1, centreOffset_ + vramWidth_ - frameWidth, vramHeight_ + 10, 0x80, 0x01);
-
-            auto errc = metadata_.Blit(frame->begin(), frame->end(), 0 /* invert no lines */, 0 /* starting from line 0 */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
-
-            if (errc)
-            {
-                printf("Failed to blit text: %s\n", errc.message().c_str());
-            }
-
-            errc = credits_.Blit(frame->begin(), frame->end(), 0 /* invert no lines */, 0 /* starting from line 0 */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
-
-            if (errc)
-            {
-                printf("Failed to blit text: %s\n", errc.message().c_str());
-            }
-
-            framePool_.AddResource(frame);
-        }
     }
 
     meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MemoryController::GetRomSelectFrame(int romIndex, uint64_t currTime)
@@ -196,17 +146,17 @@ namespace i8080_arcade
 
         if(frame != nullptr)
         {
-            if (vramWidth_ == frameWidth)
+            if (vramWidth == frameWidth)
             {
-                std::ranges::copy_n(memory_.begin() + vramOffset_, vramWidth_ * vramHeight_, frame->begin() + centreOffset_);
+                std::ranges::copy_n(memory_.begin() + vramOffset_, vramWidth * vramHeight, frame->begin() + centreOffset_);
             }
             else
             {
                 auto it = frame->begin() + centreOffset_;
 
-                for (auto vram = memory_.cbegin() + vramOffset_; vram < memory_.cbegin() + vramOffset_ + vramSize_; std::advance(vram, vramWidth_), std::advance(it, frameWidth))
+                for (auto vram = memory_.cbegin() + vramOffset_; vram < memory_.cbegin() + vramOffset_ + vramSize_; std::advance(vram, vramWidth), std::advance(it, frameWidth))
                 {
-                    std::ranges::copy_n(vram, vramWidth_, it);
+                    std::ranges::copy_n(vram, vramWidth, it);
                 }
             }
 
@@ -249,37 +199,92 @@ namespace i8080_arcade
         ++fps_;
     }
 
-    void MemoryController::Clear()
+    void MemoryController::Clear(std::vector<uint8_t>* backBuffer)
     {
         std::vector<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr> frames;
-        meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr frame;
-        bool empty = false;
-
+        auto frame = framePool_.GetResource();
         // Clear the memory to 0
         memory_.assign(memory_.size(), 0);
 
-        do
+        auto clearBuffer = [](std::vector<uint8_t>* buffer)
         {
-            frame = framePool_.GetResource();
-
-            if (frame == nullptr)
+            for (auto vram = buffer->begin() + centreOffset_; vram < buffer->cbegin() + centreOffset_ + (vramHeight * frameWidth); std::advance(vram, frameWidth))
             {
-                empty = true;
+                std::ranges::fill(vram, vram + vramWidth, 0x00);
             }
-            else
-            {
-                // Clear the vram section of the video frames
-                for (auto vram = frame->begin() + centreOffset_; vram < frame->cbegin() + centreOffset_ + (vramHeight_ * frameWidth); std::advance(vram, frameWidth))
-                {
-                    std::ranges::fill(vram, vram + vramWidth_, 0);
-                }
+        };
 
-                frames.emplace_back(std::move(frame));
-            }
+        if (backBuffer != nullptr)
+        {
+            // Clear the vram section of the back buffer
+            clearBuffer(backBuffer);
         }
-        while(empty == false);
+
+        while(frame != nullptr)
+        {
+            // Clear the vram section of the remaining buffers
+            clearBuffer(frame.get());
+            frames.emplace_back(std::move(frame));
+            frame = framePool_.GetResource();
+        }
 
         // frames will get returned to the pool once this method returns.
+    }
+
+    meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr MemoryController::MakeFramePool(int framePoolSize)
+    {
+        framePool_ = meen_hw::MH_ResourcePool<std::vector<uint8_t>>();
+
+        for(int i = 0; i < framePoolSize; i++)
+        {
+            auto frame = new std::vector<uint8_t>(frameWidth * frameHeight, 0);
+
+            // This does not take into account bounds checks ... negative values here will result in ub
+            auto blitBorder = [frameBegin = frame->begin()](int x0Start, int x1Start, int width, int y0Start, int y1Start, int height, int lpm, int rpm)
+            {
+                auto p1 = frameBegin + x1Start;
+
+                for (auto p0 = frameBegin + x0Start; p0 < frameBegin + x0Start + width; std::advance(p0, 1), std::advance(p1, 1))
+                {
+                    *p0 = *p1 = 0xFF;
+                }
+
+                p1 = frameBegin + y1Start;
+
+                for (auto p0 = frameBegin + y0Start; p0 < frameBegin + ((height - 1) * frameWidth); std::advance(p0, frameWidth), std::advance(p1, frameWidth))
+                {
+                    *p0 = lpm & 0xFF;
+                    *p1 = rpm & 0xFF;
+
+                    // This will keep the remaining pixels in the frame buffer
+                    // *p0 |= lpm;
+                    // *p1 |= rpm;
+                }
+            };
+
+            // blit a border around the surface
+            blitBorder(0, frame->size() - frameWidth, frameWidth, frameWidth, frameWidth * 2 - 1, frameHeight, 0x01, 0x80);
+            // blit a border around the vram
+            blitBorder(centreOffset_ - frameWidth, centreOffset_ + (vramHeight * frameWidth), vramWidth, centreOffset_ - frameWidth - 1, centreOffset_ + vramWidth - frameWidth, vramHeight + 10, 0x80, 0x01);
+
+            auto errc = metadata_.Blit(frame->begin(), frame->end(), 0 /* invert no lines */, 0 /* starting from line 0 */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
+
+            if (errc)
+            {
+                printf("Failed to blit text: %s\n", errc.message().c_str());
+            }
+
+            errc = credits_.Blit(frame->begin(), frame->end(), 0 /* invert no lines */, 0 /* starting from line 0 */); // maybe todo: add line to blit, much like invert - blitLineStart, blitLineCount ... probably a bit complicated for now
+
+            if (errc)
+            {
+                printf("Failed to blit text: %s\n", errc.message().c_str());
+            }
+
+            framePool_.AddResource(frame);
+        }
+
+        return framePool_.GetResource();
     }
 
     uint8_t MemoryController::Read(uint16_t addr, [[maybe_unused]] meen::IController* controller)

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -33,10 +33,11 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    RPIoController::RPIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
+    RPIoController::RPIoController(bool runAsync, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr&& backBuffer, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
         : runAsync_{ runAsync }
-		, romCount_{ romCount }
-		, romIndex_{ romCount - 1 }
+        , romCount_{ romCount }
+        , romIndex_{ romCount - 1 }
+        , backBuffer_{ std::move(backBuffer) }
     {
         i8080ArcadeIO_ = meen_hw::MakeI8080ArcadeIO();
 
@@ -49,13 +50,13 @@ namespace i8080_arcade
         width_ = videoHardware["width"].as<int>();
         height_ = videoHardware["height"].as<int>();
 
-        queue_init(&videoFrameQueue_, sizeof(uintptr_t), 2);
-        queue_init(&freeQueue_, sizeof(uintptr_t), 2);
+        queue_init(&eventDataQueue_, sizeof(uintptr_t), maxEventData_);
+        queue_init(&eventDataFreeQueue_, sizeof(uintptr_t), maxEventData_);
 
-        for(int i = 0; i < 2; i++)
+        for(int i = 0; i < maxEventData_; i++)
         {
-            auto p = std::bit_cast<uintptr_t>(&videoFrameWrapper_[i]);
-            queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
+            auto p = std::bit_cast<uintptr_t>(&eventData_[i]);
+            queue_add_blocking(&eventDataFreeQueue_, static_cast<void*>(&p));
         }
 
         spi_init(spi1, 62.5 * 1000000);
@@ -103,7 +104,7 @@ namespace i8080_arcade
 
         // Set the read / write scan direction of the frame memory
         WriteCmd(0x36); //MX, MY, RGB mode
-        WriteParam(0x70);     //0x08 bit: off - RGB,  on - BGR
+        WriteParam(0x70); //0x08 bit: off - RGB,  on - BGR
 
         // 16bpp
         WriteCmd(0x3A);
@@ -128,31 +129,12 @@ namespace i8080_arcade
         SetRegion(0, 0, width_, height_);
         // write to lcd ram
         WriteCmd(0X2C);
+
         // Write 16 bits at a time
         spi_set_format(spi1, 16, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
 
         gpio_put(Pin::DC, 1);
         gpio_put(Pin::CS, 0);
-
-        // Clear the display
-        for(int i = 0; i < height_; i++)
-        {
-             for(int j = 0; j < width_; j++)
-             {
-                 uint16_t p = 0x0000;
-                 spi_write16_blocking(spi1, &p, 1);
-             }
-        }
-
-        gpio_put(Pin::CS, 1);
-        // Write 8 bits at a time
-        spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
-        // Center the graphics on the display
-        RPIoController::SetRegion(widthOffset_, heightOffset_, width_ - widthOffset_, height_ - heightOffset_);
-        // write to lcd ram
-        RPIoController::WriteCmd(0X2C);
-        // Write 16 bits at a time
-        spi_set_format(spi1, 16, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
     }
 
     RPIoController::~RPIoController()
@@ -166,8 +148,8 @@ namespace i8080_arcade
         gpio_deinit(Pin::K3);
         gpio_deinit(Pin::RST);
         spi_deinit(spi1);
-        queue_free(&freeQueue_);
-        queue_free(&videoFrameQueue_);
+        queue_free(&eventDataFreeQueue_);
+        queue_free(&eventDataQueue_);
     }
 
     std::error_code RPIoController::LoadVideoTextures(const JsonVariantConst videoTextures, int textureWidth, int textureHeight)
@@ -211,6 +193,35 @@ namespace i8080_arcade
         textureWidth_ = textureWidth;
         textureHeight_ = textureHeight;
 
+        // Blit the first frame
+
+        gpio_put(Pin::CS, 1);
+        // Write 8 bits at a time
+        spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+        // Center the graphics on the display
+        RPIoController::SetRegion(widthOffset_, heightOffset_, width_ - widthOffset_, height_ - heightOffset_);
+        // write to lcd ram
+        RPIoController::WriteCmd(0X2C);
+        // Write 16 bits at a time
+        spi_set_format(spi1, 16, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+
+        gpio_put(Pin::DC, 1);
+        gpio_put(Pin::CS, 0);
+
+        auto bb = backBuffer_.get()->data();
+        auto compressedWidth = textureWidth_ >> 3;
+        auto dst = texture_.data();
+        auto dstSize = texture_.size();
+        auto dst16 = std::bit_cast<uint16_t*>(dst);
+
+        // loop back buffer, blit each scan line
+        for(int i = 0; i < textureHeight_; i++)
+        {
+            i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), textureWidth_, dstSize, std::span(bb, compressedWidth), MemoryController::frameWidth);
+            spi_write16_blocking(spi1, dst16, textureWidth_);
+            bb += compressedWidth;
+        }
+
         return std::error_code{};
     }
 
@@ -247,35 +258,43 @@ namespace i8080_arcade
 
                 if (ButtonPress(!gpio_get(Pin::K1), lastK1_))
                 {
-// todo: all frame buffers need to be returned to the memory controller so they can be cleared
-#if 0
-                    backBuffer_ = nullptr;
-                    VideoFrameWrapper* vfw = nullptr;
-                    queue_try_remove(&videoFrameQueue_, static_cast<void*>(&vfw));
-
-                    if (vfw != nullptr)
-                    {
-                        printf("Cancel frames\n");
-
-                        while(vfw != nullptr)
-                        {
-                            printf("Return frame to pool\n");
-                            auto videoFrame = std::move(vfw->videoFrame);
-                            // explicitly set to nullptr as there is no requirement on std::move to do this
-                            vfw->videoFrame = nullptr;
-                            auto p = std::bit_cast<uintptr_t>(vfw);
-                            queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
-
-                            vfw = nullptr;
-                            queue_try_remove(&videoFrameQueue_, static_cast<void*>(&vfw));
-                        }
-
-                        printf("End cancel frames\n");
-                    }
-#endif
+                    EventData* eventData = nullptr;
                     screen_ = Screen::RomSelect;
-                    // Clear the memmory so the loaded rom code is not executed during the rom select screen.
-                    static_cast<MemoryController*>(memoryController)->Clear();
+
+                    if (runAsync_ == true)
+                    {
+                        // Spin until the event data free queue size is full; ie all event data variants are returned, todo: ideally we would wait here
+                        while(queue_get_level(&eventDataFreeQueue_) < maxEventData_)
+                        {
+                            // do nothing
+                            printf("Waiting for final frame to blit before clearing\n");
+                        }
+                    }
+                    else
+                    {
+                        // We need to cancel any outstanding events
+                        while(queue_try_remove(&eventDataQueue_, static_cast<void*>(&eventData)) == true)
+                        {
+                            auto videoFrame = std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData);
+
+                            if (videoFrame != nullptr)
+                            {
+                                // Cancel the frame, ie; return it to the memory controller frame pool.
+                                *videoFrame = nullptr;
+                            }
+
+                            queue_add_blocking(&eventDataFreeQueue_, static_cast<void*>(&eventData));
+                        }
+                    }
+
+                    // We should now be safe to reset this as video frames can only be added from the thread we are currently on
+                    // and the spinlock/cancellation above ensures all remaining frames have been blitted/cancelled
+                    // (the HandleEvent thread (if runAsync is true) would now be in a waiting state waiting on the next frame to be added).
+                    static_cast<MemoryController*>(memoryController)->Clear(backBuffer_.get());
+                    queue_remove_blocking(&eventDataFreeQueue_, static_cast<void*>(&eventData));
+                    // Clear the vram portion of the display
+                    *eventData = true;
+                    queue_add_blocking(&eventDataQueue_, static_cast<void*>(&eventData));
                 }
                 else
                 {
@@ -356,7 +375,7 @@ namespace i8080_arcade
                     }
 
                     if (ButtonPress (!gpio_get(Pin::K3), lastK3_)) // we may need to set a callbcak on the pin since the press could be missed
-                    {                    
+                    {
                         if (--romIndex_ < 0)
                         {
                             romIndex_ = romCount_ - 1;
@@ -375,54 +394,49 @@ namespace i8080_arcade
             }
             case 2:
             {
-                VideoFrameWrapper* vfw;
-                auto success = queue_try_remove(&freeQueue_, static_cast<void*>(&vfw));
+                EventData* eventData = nullptr;
+                auto success = queue_try_remove(&eventDataFreeQueue_, static_cast<void*>(&eventData));
+
+                if (screen_ == Screen::Gameplay)
+                {
+                    isr = meen::ISR::Two;
+                }
 
                 if (success == true)
                 {
                     switch (screen_)
                     {
                         case Screen::RomSelect:
-                            vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetRomSelectFrame(romIndex_, currTime);
+                            *eventData = static_cast<MemoryController*>(memoryController)->GetRomSelectFrame(romIndex_, currTime);
                             break;
                         case Screen::Gameplay:
-                            vfw->videoFrame = static_cast<MemoryController*>(memoryController)->GetGameplayFrame(currTime);
+                            *eventData = static_cast<MemoryController*>(memoryController)->GetGameplayFrame(currTime);
                             break;
                         default:
-                            printf ("Invalid screen\n");
+                            break;
                     }
 
-                    if(vfw->videoFrame != nullptr)
-                    {
-                        auto p = std::bit_cast<uintptr_t>(vfw);
-                        success = queue_try_add(&videoFrameQueue_, static_cast<void*>(&p));
+                    auto videoFrame = std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData);
 
-                        if(success == false)
-                        {
-                            printf("Failed to add frame to video queue\n");
-                            // explicitly null the video frame so it is returned to the memory frame pool.
-                            vfw->videoFrame = nullptr;
-                            queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
-                        }
-                    }
-                    else
+                    // The variant is in an invalid state or no video frame was generated.
+                    if (videoFrame == nullptr || *videoFrame == nullptr)
                     {
-                        printf("CORE 1 dropped\n");
+                        *eventData = "Failed to get the frame from the memory controller, frame dropped";
                     }
+
+                    success = queue_try_add(&eventDataQueue_, static_cast<void*>(&eventData));
+                    assert(success == true);
                 }
                 else
                 {
-                    printf("1 Video frame dropped, renderer too slow\n");
-                }
-
-                if (screen_ == Screen::Gameplay)
-                {
-                    isr = meen::ISR::Two;
+                    printf("Failed to dispatch video frame, increase the event data pool size\n");
+                    // assert(0);
                 }
                 break;
             }
             default:
             {
+                assert(interrupt >= 0 && interrupt <= 2);
                 break;
             }
         }
@@ -470,59 +484,82 @@ namespace i8080_arcade
 
     bool RPIoController::HandleEvent()
     {
-        VideoFrameWrapper* vfw = nullptr;
+        EventData* eventData = nullptr;
 
         if (runAsync_ == true)
         {
-            queue_remove_blocking(&videoFrameQueue_, static_cast<void*>(&vfw));
+            queue_remove_blocking(&eventDataQueue_, static_cast<void*>(&eventData));
         }
         else
         {
-            if (queue_try_remove(&videoFrameQueue_, static_cast<void*>(&vfw)) == false)
+            if (queue_try_remove(&eventDataQueue_, static_cast<void*>(&eventData)) == false)
             {
                 return false;
             }
         }
 
-        auto videoFrame = std::move(vfw->videoFrame);
-        // explicitly set to nullptr as there is no requirement on std::move to do this
-        vfw->videoFrame = nullptr;
-        auto p = std::bit_cast<uintptr_t>(vfw);
-        queue_add_blocking(&freeQueue_, static_cast<void*>(&p));
-
-        if (videoFrame != nullptr)
-        {
-            auto compressedWidth = textureWidth_ >> 3;
-            auto dst = texture_.data();
-            auto dstSize = texture_.size();
-            auto dst16 = std::bit_cast<uint16_t*>(dst);
-            auto vf = videoFrame.get()->data();
-            uint8_t* bb = nullptr;
-
-            if(backBuffer_ != nullptr)
+        auto quit = std::visit(overloaded
+	{
+            [](const std::string& error)
             {
-                bb = backBuffer_.get()->data();
-            }
-
-            gpio_put(Pin::DC, 1);
-            gpio_put(Pin::CS, 0);
-
-            for(int i = 0/*, lastScanline = 0*/; i < textureHeight_; i++)
+                printf("%s\n", error.c_str());
+                return false;
+            },
+            [this](bool clear)
             {
-                // Blit a scanline at a time for performance reasons
-
-                // Utilise a back buffer so we only render scanlines that have changed
-                if(bb != nullptr)
+                if (clear == true)
                 {
-                    // Check to see if this scanline has changed compared to its counterpart in the previous frame
+                    // The vram is positioned at the center of the display
+                    int ho = (height_ - MemoryController::vramHeight) / 2;
+                    // The vram is 1bpp hence we need to multiply the width by 8
+                    int wo = (width_ - (MemoryController::vramWidth << 3)) / 2;
+
+                    // Clear the centre of the display (where the vram is blitted), one row at a time
+                    for(int i = ho; i < ho + MemoryController::vramHeight; i++)
+                    {
+                        gpio_put(Pin::CS, 1);
+                        // Write 8 bits at a time
+                        spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+                        // Clear the blittable region to the current row
+                        RPIoController::SetRegion(wo, i /* row start */, width_ - wo, 1/* Cover a height of 1, ie; 1 row*/);
+                        // Write to lcd ram
+                        RPIoController::WriteCmd(0X2C);
+                        // Write 16 bits at a time
+                        spi_set_format(spi1, 16, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+
+                        gpio_put(Pin::DC, 1);
+                        gpio_put(Pin::CS, 0);
+
+                        // Clear the current row of the display
+                        for(int j = 0; j < MemoryController::vramWidth << 3; j++)
+                        {
+                            uint16_t p = 0x0000;
+                            spi_write16_blocking(spi1, &p, 1);
+                        }
+                    }
+                }
+
+                return false;
+            },
+            [this](meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr& videoFrame)
+            {
+                auto compressedWidth = textureWidth_ >> 3;
+                auto dst = texture_.data();
+                auto dstSize = texture_.size();
+                auto dst16 = std::bit_cast<uint16_t*>(dst);
+                auto vf = videoFrame.get()->data();
+                uint8_t* bb = backBuffer_.get()->data();
+
+                for(int i = 0, lastScanline = 0; i < textureHeight_; i++, bb += compressedWidth, vf += compressedWidth)
+                {
+                    // Blit a scanline at a time for performance reasons
+
+                    // Check to see if this scanline has changed compared to its counterpart in the back buffer (previous frame)
                     if(std::memcmp(bb, vf, compressedWidth) != 0)
                     {
                         // Update the region only if the scanline to be rendered is non contiguous from the previous scanline
-                        // TODO: this minor optimisation yields rendering errors, requires further investigation if it is needed.
-                        //if(i - lastScanline > 1)
+                        if(i - lastScanline > 1)
                         {
-                            //setRegion(i);
-
                             gpio_put(Pin::CS, 1);
                             // Write 8 bits at a time
                             spi_set_format(spi1, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
@@ -542,43 +579,40 @@ namespace i8080_arcade
                         spi_write16_blocking(spi1, dst16, textureWidth_);
 
                         // Update the last scanline index
-                        //lastScanline = i;
+                        lastScanline = i;
                     }
 //                  else
 //                      this scanline is the same as its counterpart in the previous frame, no need to render this scanline
-
-                    // Move to the next scanline in the back buffer
-                    bb += compressedWidth;
-                }
-                else
-                {
-                    i8080ArcadeIO_->BlitVRAM(std::span(dst, dstSize), textureWidth_, dstSize, std::span(vf, compressedWidth), MemoryController::frameWidth);
-                    spi_write16_blocking(spi1, dst16, textureWidth_);
                 }
 
-                // Move to the next scanline in the front buffer
-                vf += compressedWidth;
+                // We are done, move the video frame to the back buffer.
+                // This will return the previous back buffer to the memory controller frame pool.
+                backBuffer_ = std::move(videoFrame);
+                return false;
             }
+        }, *eventData);
 
-            gpio_put(Pin::CS, 1);
+        queue_add_blocking(&eventDataFreeQueue_, static_cast<void*>(&eventData));
 
-            // We are done, swap the front and back buffers
-            std::swap(backBuffer_, videoFrame);
-
-            // Explicitly set to nullptr so it is immediately returned to the memory controller.
-            videoFrame = nullptr;
-        }
-        else
-        {
-            printf("Video frame dropped\n");
-        }
-
-        return false;
+        return quit;
     }
 
     void RPIoController::HandleError(std::string&& errorMsg)
     {
-        printf("%s\n", errorMsg.c_str());
+        EventData* eventData = nullptr;
+
+        queue_remove_blocking(&eventDataFreeQueue_, static_cast<void*>(&eventData));
+
+        if (eventData != nullptr)
+        {
+            *eventData = std::move(errorMsg);
+            queue_add_blocking(&eventDataQueue_, static_cast<void*>(&eventData));
+        }
+        else
+        {
+            printf("Failed to dispatch error message, increase the event data pool size\n");
+            //assert(0);
+        }
     }
 
     std::tuple<bool, int> RPIoController::GetRomIndex()

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -346,7 +346,8 @@ namespace i8080_arcade
 							{
 								screen_ = Screen::RomSelect;
 								// Clear the memory controller ram and frame buffers
-								static_cast<MemoryController*>(controller)->Clear();
+								// We don't use a back buffer with this controller, pass nullptr
+								static_cast<MemoryController*>(controller)->Clear(nullptr);
 							}
 						}
 					}
@@ -378,7 +379,13 @@ namespace i8080_arcade
 							if (eventData != nullptr)
 							{
 								// The resource (if it exists) will get returned to the frame pool after the completion of this block
-								auto videoFrame = std::move(std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData));
+								auto videoFrame = std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData);
+								
+								if (videoFrame != nullptr)
+								{
+									*videoFrame = nullptr;
+								}
+
 								// We are single threaded, so we don't need to lock this.
 								eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
 							}
@@ -386,9 +393,8 @@ namespace i8080_arcade
 
 						screen_ = Screen::RomSelect;
 						// Clear the memory controller ram and frame buffers
-						static_cast<MemoryController*>(controller)->Clear();
-
-						// todo: for the RPIoController we need to clear the back buffer
+						// We don't use a back buffer with this controller, pass nullptr
+						static_cast<MemoryController*>(controller)->Clear(nullptr);
 					}
 				}
 			}
@@ -470,13 +476,20 @@ namespace i8080_arcade
 			}
 			case 1:
 			{
-				isr = meen::ISR::One;
+				if (screen_ == Screen::Gameplay)
+				{
+					isr = meen::ISR::One;
+				}
 				break;
 			}
 			case 2:
 			{
-				isr = meen::ISR::Two;
 				auto eventData = GetEventData();
+
+				if (screen_ == Screen::Gameplay)
+				{
+					isr = meen::ISR::Two;
+				}
 
 				if(eventData != nullptr)
 				{
@@ -494,11 +507,14 @@ namespace i8080_arcade
 							break;
 					}
 
-					if (*std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData) == nullptr)
+					auto videoFrame = std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData);
+
+					// The variant is in an invalid state or no video frame was generated.
+					if (videoFrame == nullptr || *videoFrame == nullptr)
 					{
 						*eventData = "Failed to get the frame from the memory controller, frame dropped";
 					}
-					
+
 					SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
 					e.user.data1 = eventData;
 					e.user.data2 = nullptr;
@@ -657,10 +673,10 @@ namespace i8080_arcade
 						return false;
 					}
 				}, *eventData);
-						
+
 				// We are done with the event data, return it back to the event data pool
 				std::lock_guard<std::mutex> lg(eventDataMutex_);
-				eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));						
+				eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
 			}
 			else
 			{
@@ -687,6 +703,7 @@ namespace i8080_arcade
 		else
 		{
 			printf("Failed to dispatch error message, increase the event data pool size\n");
+			//assert(0);
 		}
 	}
 } // namespace i8080_arcade

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -89,20 +89,13 @@ namespace i8080_arcade
 		SDL_SetEventFilter([](void* eventType, SDL_Event* e)
 		{
 			// Ignore all events except ours.
-			if (reinterpret_cast<uint64_t>(eventType) == e->type || e->type == SDL_QUIT)
-			{
-				return 1;
-			}
-			else
-			{
-				return 0;
-			}
+			return static_cast<int>((reinterpret_cast<uint64_t>(eventType) == e->type || e->type == SDL_QUIT) == true);
 		},
 		reinterpret_cast<void*>(siEvent_));
 
-		for(int i = 0; i < 1; i++)
+		for(int i = 0; i < 2; i++)
 		{
-			videoFrameWrapperPool_.emplace_back(std::make_unique<VideoFrameWrapper>());
+			eventDataPool_.emplace_back(std::make_unique<EventData>());
 		}
 	}
 
@@ -301,6 +294,21 @@ namespace i8080_arcade
 		return value;
 	}
 
+	std::variant<std::string, uint8_t, uint16_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>* SDLIoController::GetEventData()
+	{
+		EventData* eventData = nullptr;
+
+		std::lock_guard<std::mutex> lg(eventDataMutex_);
+
+		if (eventDataPool_.empty() == false)
+		{
+			eventData = eventDataPool_.back().release();
+			eventDataPool_.pop_back();
+		}
+
+		return eventData;
+	}
+
 	uint8_t SDLIoController::Read(uint16_t port, [[maybe_unused]] meen::IController* controller)
 	{
 		auto ret = i8080ArcadeIO_->ReadPort(port);
@@ -311,32 +319,41 @@ namespace i8080_arcade
 			{
 				if (runAsync_ == true)
 				{
-					// This block isn't ideal as it pushes a request to the main
-					// thread and waits for a result ... I don't think we can
-					// remove this and just perform the else case as I don't think
-					// it is safe to do so with SDL across threads.
-					std::promise<uint16_t> p;
-					SDL_Event e{};
-					e.type = siEvent_;
-					e.user.code = EventCode::ReadInput;
-					e.user.data1 = reinterpret_cast<void*>(port);
-					e.user.data2 = reinterpret_cast<void*>(&p);
-					SDL_PushEvent(&e);
+					auto eventData = GetEventData();
 
-					if (quit_ == false)
+					if (eventData != nullptr)
 					{
-						auto val = p.get_future().get();
+						// This block isn't ideal as it pushes a request to the main
+						// thread and waits for a result ... I don't think we can
+						// remove this and just perform the else case as I don't think
+						// it is safe to do so with SDL across threads.
+						std::promise<uint16_t> p;
+						SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
+						*eventData = port;
+						e.user.data1 = reinterpret_cast<void*>(eventData);
+						e.user.data2 = reinterpret_cast<void*>(&p);
+						SDL_PushEvent(&e);
 
-						if (val <= 0xFF)
+						if (quit_ == false)
 						{
-							ret = static_cast<uint8_t>(val);
+							auto val = p.get_future().get();
+
+							if (val <= 0xFF)
+							{
+								ret = static_cast<uint8_t>(val);
+							}
+							else
+							{
+								screen_ = Screen::RomSelect;
+								// Clear the memory controller ram and frame buffers
+								static_cast<MemoryController*>(controller)->Clear();
+							}
 						}
-						else
-						{
-							screen_ = Screen::RomSelect;
-							// Clear the memory controller ram and frame buffers
-							static_cast<MemoryController*>(controller)->Clear();
-						}
+					}
+					else
+					{
+						printf("Failed to dispatch keyboard read, increase the event data pool size\n");
+						//assert(0);
 					}
 				}
 				else
@@ -351,20 +368,19 @@ namespace i8080_arcade
 					{
 						SDL_Event e;
 
-						// In single threaded mode we need to abort the current frame to be rendered and return the wrapper
-						// and its frame to their respective pools so that the frame can be cleared.
-						if (SDL_PollEvent(&e))
+						// In single threaded mode we need to remove all outstanding i8080 arcade events, return the video frames
+						// back to the memory controller so they can be cleared, then return the event data back to the pool.
+						while (SDL_PeepEvents(&e, 1, SDL_GETEVENT, siEvent_, siEvent_) > 0)
 						{
-							if (e.type == siEvent_ && e.user.code == EventCode::RenderVideo)
-							{
-								auto videoFrameWrapper = std::bit_cast<VideoFrameWrapper*>(e.user.data1);
+							auto eventData = std::bit_cast<EventData*>(e.user.data1);
+							assert(eventData != nullptr);
 
-								if (videoFrameWrapper != nullptr)
-								{
-									auto videoFrame = std::move(videoFrameWrapper->videoFrame);
-									// We are single threaded, so we don't need to lock this.
-									videoFrameWrapperPool_.push_back(std::unique_ptr<VideoFrameWrapper>(videoFrameWrapper));
-								}
+							if (eventData != nullptr)
+							{
+								// The resource (if it exists) will get returned to the frame pool after the completion of this block
+								auto videoFrame = std::move(std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData));
+								// We are single threaded, so we don't need to lock this.
+								eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
 							}
 						}
 
@@ -387,12 +403,21 @@ namespace i8080_arcade
 
 		if (audio > 0)
 		{
-			SDL_Event e{};
-			e.type = siEvent_;
-			e.user.code = EventCode::RenderAudio;
-			e.user.data1 = reinterpret_cast<void*>(port);
-			e.user.data2 = reinterpret_cast<void*>(audio);
-			SDL_PushEvent(&e);
+			auto eventData = GetEventData();
+
+			if (eventData != nullptr)
+			{
+				SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
+				*eventData = static_cast<uint8_t>(port);
+				e.user.data1 = reinterpret_cast<void*>(eventData);
+				e.user.data2 = reinterpret_cast<void*>(audio);
+				SDL_PushEvent(&e);
+			}
+			else
+			{
+				printf("Failed dispatch audio, increase the event data pool size\n");
+				//assert(0);
+			}
 		}
 	}
 
@@ -451,43 +476,39 @@ namespace i8080_arcade
 			case 2:
 			{
 				isr = meen::ISR::Two;
-				VideoFrameWrapper* videoFrameWrapper = nullptr;
+				auto eventData = GetEventData();
 
-				{
-					std::lock_guard<std::mutex> lg(videoFrameWrapperMutex_);
-
-					if(videoFrameWrapperPool_.empty() == false)
-					{
-						videoFrameWrapper = videoFrameWrapperPool_.back().release();
-					}
-				}
-
-				if(videoFrameWrapper != nullptr)
+				if(eventData != nullptr)
 				{
 					auto mc = static_cast<MemoryController*>(memoryController);
 
 					switch (screen_)
 					{
 						case Screen::RomSelect:
-							videoFrameWrapper->videoFrame = mc->GetRomSelectFrame(romIndex_, currTime);
+							*eventData = mc->GetRomSelectFrame(romIndex_, currTime);
 							break;
 						case Screen::Gameplay:
-							videoFrameWrapper->videoFrame = mc->GetGameplayFrame(currTime);
+							*eventData = mc->GetGameplayFrame(currTime);
 							break;
 						default:
-							printf("Invalid screen\n");
 							break;
 					}
-				}
 
-				SDL_Event e{};
-				e.type = siEvent_;
-				e.user.code = EventCode::RenderVideo;
-				// Allow events where the vram is nullptr to be pushed so we can track
-				// dropped frames in the main thread.
-				e.user.data1 = videoFrameWrapper;
-				e.user.data2 = nullptr;
-				SDL_PushEvent(&e);
+					if (*std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData) == nullptr)
+					{
+						*eventData = "Failed to get the frame from the memory controller, frame dropped";
+					}
+					
+					SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
+					e.user.data1 = eventData;
+					e.user.data2 = nullptr;
+					SDL_PushEvent(&e);
+				}
+				else
+				{
+					printf("Failed to dispatch video frame, increase the event data pool size\n");
+//					assert(0);
+				}
 				break;
 			}
 			default:
@@ -509,172 +530,142 @@ namespace i8080_arcade
 	{
 		SDL_Event e;
 		bool quit = false;
-		bool eventTriggered = false;
 		const auto state = SDL_GetKeyboardState(nullptr);
-
-		if (runAsync_ == true)
-		{
-			eventTriggered = SDL_WaitEvent(&e);
-		}
-		else
-		{
-			eventTriggered = SDL_PollEvent(&e);
-		}
+		bool eventTriggered = runAsync_ == true ? SDL_WaitEvent(&e) : SDL_PollEvent(&e);
 
 		if (eventTriggered == true)
 		{
-			switch (e.type)
+			if(e.type == siEvent_)
 			{
-				case SDL_QUIT:
+				auto eventData = std::bit_cast<EventData*>(e.user.data1);
+
+				quit = std::visit(overloaded
 				{
-					quit_ = quit = true;
-					break;
-				}
-				default:
-				{
-					if(e.type == siEvent_)
+					[](const std::string& error)
 					{
-						switch (e.user.code)
+						printf("%s\n", error.c_str());
+						return false;
+					},
+					[this, state, &e](uint16_t port)
+					{
+						auto p = static_cast<std::promise<uint16_t>*>(e.user.data2);
+						state[SDL_SCANCODE_ESCAPE] ? p->set_value(0x100) : p->set_value(ReadInputDevice(port, state));
+						return false;
+					},
+					[this, &e](uint8_t port)
+					{
+						std::bitset<8> audio = reinterpret_cast<uint64_t>(e.user.data2);
+						// port will either be 3 or 5
+						// when port is 3 index will be 0 and when it is 5 it will be 8
+						// which will give the correct offset into the mixChunk_ array
+						auto offset = (port - 3) << 2;
+
+						for (int i = 0; i < 8; i++)
 						{
-							case EventCode::RenderVideo:
+							/*
+								todo: if the audio is ufo, we need to loop it rather than playing the sample again.
+										this should fix the stall in single threaded mode
+
+								if audio.test(i) is ufo and ufo not playing
+									mix play channel (repeat the sample)
+
+								if audio.test(i) != ufo and ufo playing
+									mix play channel (stop the sample)
+							*/
+
+							if (audio.test(i) == true)
 							{
-								quit = state[SDL_SCANCODE_Q];
-
-								if (quit == true)
-								{
-									quit_ = true;
-
-									if (runAsync_ == true)
-									{
-										if (SDL_PollEvent(&e))
-										{
-											if (e.type == siEvent_ && e.user.code == EventCode::ReadInput)
-											{
-												static_cast<std::promise<uint8_t>*>(e.user.data2)->set_value(0);
-											}
-										}
-									}
-									break;
-								}
-
-								auto videoFrameWrapper = std::bit_cast<VideoFrameWrapper*>(e.user.data1);
-
-								if (videoFrameWrapper != nullptr)
-								{
-									// Move the frame out of the wrapper. This must be done as it allows the
-									// video frame to be returned back to the memory controller, alternatively,
-									// one could set videoFrameWrapper->videoFrame to nullptr once it is no longer
-									// needed.
-									auto videoFrame = std::move(videoFrameWrapper->videoFrame);
-									// We are done with the wrapper, return it back to the wrapper pool
-									{
-										std::lock_guard<std::mutex> lg(videoFrameWrapperMutex_);
-										videoFrameWrapperPool_.push_back(std::unique_ptr<VideoFrameWrapper>(videoFrameWrapper));
-									}
-
-									if (videoFrame != nullptr)
-									{
-										uint8_t* dst = nullptr;
-										int rowBytes = 0;
-
-										if (SDL_LockTexture(texture_, nullptr, std::bit_cast<void**>(&dst), &rowBytes) == 0)
-										{
-											i8080ArcadeIO_->BlitVRAM(std::span(dst, dstRect_.h * rowBytes), dstRect_.w, rowBytes, std::span(*videoFrame), MemoryController::frameWidth);
-											SDL_UnlockTexture(texture_);
-										}
-										else
-										{
-											printf("Failed to lock texture, video frame dropped\n");
-										}
-									}
-									else
-									{
-										printf("Video frame dropped\n");
-									}
-								}
-								else
-								{
-									printf("Wrapper empty, video frame dropped\n");
-								}
-
-								SDL_RenderCopy(renderer_, texture_, nullptr, &dstRect_);
-								SDL_RenderPresent(renderer_);
-								
-								auto scrollIndex = [this](Uint8 key, Uint8 lastKey, int dir)
-								{
-									if (key ^ lastKey && key)
-									{
-										int romIndex = romIndex_;
-
-										romIndex = (romIndex + dir) % romCount_;
-
-										if (romIndex < 0)
-										{
-											romIndex = romCount_ - 1;
-										}
-
-										romIndex_ = romIndex;
-									}
-
-									return key;
-								};
-
-								lastUp_ = scrollIndex(state[SDL_SCANCODE_UP], lastUp_, 1);
-								lastDown_ = scrollIndex(state[SDL_SCANCODE_DOWN], lastDown_, -1);
-								// Check to see if the user wants to load a rom.
-								// This will only be acknowledged in ServiceInterrupts if screen_ is RomSelect,
-								// we could check screen_ for RomSelect here, but that would mean select_ would have
-								// to be atomic.
-								lastReturn_ = SetInterrupt(state[SDL_SCANCODE_RETURN], lastReturn_, meen::ISR::Load, false);
-								break;
-							}
-							case EventCode::RenderAudio:
-							{
-								uint8_t port = reinterpret_cast<uint64_t>(e.user.data1);
-								std::bitset<8> audio = reinterpret_cast<uint64_t>(e.user.data2);
-								// port will either be 3 or 5
-								// when port is 3 index will be 0 and when it is 5 it will be 8
-								// which will give the correct offset into the mixChunk_ array
-								auto offset = (port - 3) << 2;
-
-								for (int i = 0; i < 8; i++)
-								{
-									/*
-										todo: if the audio is ufo, we need to loop it rather than playing the sample again.
-											  this should fix the stall in single threaded mode
-
-										if audio.test(i) is ufo and ufo not playing
-											mix play channel (repeat the sample)
-
-										if audio.test(i) != ufo and ufo playing
-											mix play channel (stop the sample)
-									*/
-
-									if (audio.test(i) == true)
-									{
-										[[maybe_unused]] auto busy = Mix_PlayChannel(-1 /* use the next available channel */, mixChunk_[i + offset], 0 /* don't loop (play it once) */);
-										// We are playing 8 (default maximum) samples at the same time, this should not happen!
-										// We are trying to play a track which isn't loaded (an unknown data bit is set?!?!)
-										//assert(mixChunk_[i] == nullptr || busy != -1);
-									}
-								}
-								break;
-							}
-							case EventCode::ReadInput:
-							{
-								uint8_t port = reinterpret_cast<uint64_t>(e.user.data1);
-								auto p = static_cast<std::promise<uint16_t>*>(e.user.data2);
-								state[SDL_SCANCODE_ESCAPE] ? p->set_value(0x100) :  p->set_value(ReadInputDevice(port, state));
-								break;
-							}
-							default:
-							{
-								break;
+								[[maybe_unused]] auto busy = Mix_PlayChannel(-1 /* use the next available channel */, mixChunk_[i + offset], 0 /* don't loop (play it once) */);
+								// We are playing 8 (default maximum) samples at the same time, this should not happen!
+								// We are trying to play a track which isn't loaded (an unknown data bit is set?!?!)
+								//assert(mixChunk_[i] == nullptr || busy != -1);
 							}
 						}
+
+						return false;
+					},
+					[this, state, &e](meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr& videoFrame)
+					{
+						if (state[SDL_SCANCODE_Q] != 0)
+						{
+							quit_ = true;
+
+							if (runAsync_ == true)
+							{
+								// We are done with the event data, return it back to the event data pool
+								std::lock_guard<std::mutex> lg(eventDataMutex_);
+
+								while (SDL_PeepEvents(&e, 1, SDL_GETEVENT, siEvent_, siEvent_) > 0)
+								{
+									auto ed = std::bit_cast<EventData*>(e.user.data1);
+									assert(ed != nullptr);
+									auto port = std::get_if<uint16_t>(ed);
+
+									if (port != nullptr)
+									{
+										auto p = static_cast<std::promise<uint8_t>*>(e.user.data2);
+										assert(p != nullptr);
+										p->set_value(0);
+									}
+
+									eventDataPool_.push_back(std::unique_ptr<EventData>(ed));
+								}
+							}
+
+							return true;
+						}
+
+						uint8_t* dst = nullptr;
+						int rowBytes = 0;
+						// For performance reasons we'll just run an assert on the following applicable SDL methods
+						auto err = SDL_LockTexture(texture_, nullptr, std::bit_cast<void**>(&dst), &rowBytes);
+						assert(err == 0);
+						i8080ArcadeIO_->BlitVRAM(std::span(dst, dstRect_.h * rowBytes), dstRect_.w, rowBytes, std::span(*(videoFrame.get())), MemoryController::frameWidth);
+						SDL_UnlockTexture(texture_);
+						// We are done with the frame, return it immediately to the memory controller by explicitly setting it to nullptr
+						videoFrame = nullptr;
+						err = SDL_RenderCopy(renderer_, texture_, nullptr, &dstRect_);
+						assert(err == 0);
+						SDL_RenderPresent(renderer_);
+
+						auto scrollIndex = [this](Uint8 key, Uint8 lastKey, int dir)
+						{
+							if (key ^ lastKey && key)
+							{
+								int romIndex = romIndex_;
+
+								romIndex = (romIndex + dir) % romCount_;
+
+								if (romIndex < 0)
+								{
+									romIndex = romCount_ - 1;
+								}
+
+								romIndex_ = romIndex;
+							}
+
+							return key;
+						};
+
+						lastUp_ = scrollIndex(state[SDL_SCANCODE_UP], lastUp_, 1);
+						lastDown_ = scrollIndex(state[SDL_SCANCODE_DOWN], lastDown_, -1);
+						// Check to see if the user wants to load a rom.
+						// This will only be acknowledged in ServiceInterrupts if screen_ is RomSelect,
+						// we could check screen_ for RomSelect here, but that would mean screen_ would have
+						// to be atomic.
+						lastReturn_ = SetInterrupt(state[SDL_SCANCODE_RETURN], lastReturn_, meen::ISR::Load, false);
+						return false;
 					}
-					break;
-				}
+				}, *eventData);
+						
+				// We are done with the event data, return it back to the event data pool
+				std::lock_guard<std::mutex> lg(eventDataMutex_);
+				eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));						
+			}
+			else
+			{
+				assert(e.type == SDL_QUIT);
+				quit_ = quit = true;
 			}
 		}
 
@@ -683,6 +674,19 @@ namespace i8080_arcade
 
 	void SDLIoController::HandleError(std::string&& errorMsg)
 	{
-		printf("%s\n", errorMsg.c_str());
+		auto eventData = GetEventData();
+
+		if (eventData != nullptr)
+		{
+			*eventData = std::move(errorMsg);
+			SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
+			e.user.data1 = eventData;
+			e.user.data2 = nullptr;
+			SDL_PushEvent(&e);
+		}
+		else
+		{
+			printf("Failed to dispatch error message, increase the event data pool size\n");
+		}
 	}
 } // namespace i8080_arcade

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -119,20 +119,20 @@ if(value)\
 static i8080_arcade::MemoryController* MakeMemoryController(const std::vector<std::pair<std::string, std::string>>&jsonRoms)
 {
 #ifdef ENABLE_MH_RP2040
-	return new i8080_arcade::MemoryController(jsonRoms, 3); // 3 - Three frame for triple buffered rendering
+	return new i8080_arcade::MemoryController(jsonRoms);
 #else
 	return new i8080_arcade::MemoryController(jsonRoms);
 #endif
 }
 
-static i8080_arcade::IIoController* MakeIoController(bool runAsync, int romCount, JsonVariantConst audioHardware, JsonVariantConst videoHardware)
+static i8080_arcade::IIoController* MakeIoController(bool runAsync, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr&& backBuffer, int romCount, JsonVariantConst audioHardware, JsonVariantConst videoHardware)
 {
 	if (!audioHardware|| !videoHardware)
 	{
 		return nullptr;
 	}
 #ifdef ENABLE_MH_RP2040
-	return new i8080_arcade::RPIoController(runAsync, romCount, audioHardware, videoHardware);
+	return new i8080_arcade::RPIoController(runAsync, std::move(backBuffer), romCount, audioHardware, videoHardware);
 #else
 	return new i8080_arcade::SDLIoController(runAsync, romCount, audioHardware, videoHardware);
 #endif // ENABLE_MH_RP2040
@@ -220,13 +220,21 @@ int main(int argc, char** argv)
 		auto meen = hardware["meen"];
 		CHECK_ERROR(!meen, printf("Invalid json config file format: meen section not found\n"));
 
-		// Create our custom i8080 arcade I/O controller based on a specific configuration.
-		auto ioController = MakeIoController(meen["runAsync"], jsonRoms.size(), hardware["audio"], hardware["video"]);
-		CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
-
 		// Create our custom i8080 arcade memory controller.
 		auto memoryController = MakeMemoryController(jsonRoms);
 		CHECK_ERROR(!memoryController, printf("Failed to create the memory controller\n"));
+
+		// Create a frame pool of 2 frames, passing an empty one back for use as the initial io controller back buffer if required.
+		auto backBuffer = memoryController->MakeFramePool(2);
+		CHECK_ERROR(!backBuffer, printf("Failed to create the memory controller frame pool\n"));
+
+		// Create our custom i8080 arcade I/O controller based on a specific configuration.
+		auto ioController = MakeIoController(meen["runAsync"], std::move(backBuffer), jsonRoms.size(), hardware["audio"], hardware["video"]);
+		CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
+
+		// todo: call a method that will create the event pool
+		// auto err = ioController->MakeEventPool(2);
+		// CHECK_ERROR(err, printf("Failed to create the io controller event pool\n");
 
 		// Set up the custom controllers prior to configuring the machine.
 


### PR DESCRIPTION
- The handling of events is now done with the use of std::variant rather than the event code enum (which has been removed). This has allowed for the removal of superfluous boilerplate code.
- Fixed rp2040 rendering errors (stale frames being rendered) when transitioning from the rom select screen to the game play screen and vice versa.
- Enabled the rp2040 io controller optimisation of only setting the blitting region when scanlines to be rendered are non- contiguous.
- Various documentation updates and corrections.