### PR TITLE
#110 fix: user input handling

### DIFF
--- a/include/i8080_arcade/IIoController.h
+++ b/include/i8080_arcade/IIoController.h
@@ -96,7 +96,7 @@ namespace i8080_arcade
 		*/
 		virtual std::tuple<bool, int> GetRomIndex() = 0;
 
-        /** Free any use resources
+        /** Free any used resources
             
         */
         virtual ~IIoController() = default;

--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -24,6 +24,7 @@ SOFTWARE.
 #define RPIOCONTROLLER_H
 
 #include <ArduinoJson.h>
+#include <atomic>
 #include <pico/util/queue.h>
 #include <variant>
 #include <vector>
@@ -33,7 +34,7 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
-    /** Custom SDL io controller.
+    /** Custom Raspberry Pi Pico  io controller.
 
         A custom io controller targetting Space Invaders i8080 arcade hardware compatible ROMs.
     */
@@ -53,8 +54,43 @@ namespace i8080_arcade
             K0 = 15,
             K1 = 17,
             K2 = 2,
-            K3 = 3
+            K3 = 3,
+            MAX = 18
         };
+
+        /** The current active button
+
+            True if the button (pin) is pressed, false otherwise
+
+            @remark    Only the pins K0, K1, K2, K3 are tracked (the remaining entries are unused).
+        */
+        static bool buttonPress_[Pin::MAX];
+
+        /** The previous edge fall state
+
+            Track the previous edge fall state to prevent spurious edge falls (when an edge fall is
+            detected but the previous edge fall for that pin is set, then this is a spurious edge fall).
+
+            @remark    Only the pins K0, K1, K2, K3 are tracked (the remaining entries are unused).
+        */
+        static bool prevEdgeFall_[Pin::MAX];
+
+        /** The previous edge rise state
+
+            Track the previous edge rise state to prevent spurious edge rises (when an edge rise is
+            detected but the previous edge rise for that pin is set, then this is a spurious edge rise).
+
+            @remark    Only the pins K0, K1, K2, K3 are tracked (the remaining entries are unused).
+        */
+        static bool prevEdgeRise_[Pin::MAX];
+
+        /** One time callback registration
+
+            TODO: this needs to be removed once an initialisation registration
+                  handler has been added to MEEN.
+
+        */
+        static bool gpioCallbackRegistered_;
 
         /** Output device width
 
@@ -122,29 +158,29 @@ namespace i8080_arcade
         */
         std::unique_ptr<meen_hw::MH_II8080ArcadeIO> i8080ArcadeIO_;
 
-	    /** Helper type for functional style visitor for std::visit
+        /** Helper type for functional style visitor for std::visit
 
-	        This template helper type is taken straight from cppreference std::visit examples (https://en.cppreference.com/w/cpp/utility/variant/visit2)
-	    */
-	    template<class... Ts>
-	    struct overloaded : Ts... { using Ts::operator()...; };
+            This template helper type is taken straight from cppreference std::visit examples (https://en.cppreference.com/w/cpp/utility/variant/visit2)
+        */
+        template<class... Ts>
+        struct overloaded : Ts... { using Ts::operator()...; };
 
-	    /** Generated event data
+        /** Generated event data
 
             A using directve for ease of use. This will hold the active event data to be processed.
 
             bool:        True to clear the vram area of the lcd display, false otherwise.
             std::string: The application has encountered and error.
             ResourcePtr: The next video frame is ready to be rendered. This event drives the control loop.
-	    */
-	    using EventData = std::variant<std::string, bool, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
+        */
+        using EventData = std::variant<std::string, bool, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
 
-	    /** A finite EventData resource pool
+        /** A finite EventData resource pool
 
-            A vector of EventData variants to be used during the event handleing process.
+            A vector of EventData variants to be used during the event handling process.
 
             @remark    Populate from a fnite array of EventData objects
-	    */
+        */
         queue_t eventDataQueue_;
 
         /** Available event data queue
@@ -214,7 +250,7 @@ namespace i8080_arcade
             True if meen is to run on core 1, false to run on core 0 with
             the main application.
         */
-        bool runAsync_{};
+        const bool runAsync_{};
 
         /** The current screen
 
@@ -248,17 +284,10 @@ namespace i8080_arcade
         */
         static void SetRegion(uint16_t Xstart, uint16_t Ystart, uint16_t Xend, uint16_t Yend);
 
-        /** Single button press
+        /** One time callback registration for gpio handling
 
-            Returns the state of tthe button (ignoring repeats).
-
-            bool    button        True of the button is currently pressed.
-            bool    lastButton    The prevos state of the button parameter.
-                                  True this is a button repeat, false otherwise.
-
-            return                True for a single press, false otherwise.
         */
-        bool ButtonPress(bool button, bool& lastButton);
+        static void RegisterGpioCallback();
 
     public:
         /** Initialisation constructor

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -26,6 +26,7 @@ SOFTWARE.
 #define ARDUINOJSON_ENABLE_STRING_VIEW 1
 #include <ArduinoJson.h>
 #include <atomic>
+#include <condition_variable>
 #include <SDL.h>
 #include <SDL_mixer.h>
 #include <variant>
@@ -104,14 +105,13 @@ namespace i8080_arcade
 
 				A using directve for ease of use. This will hold the active event data to be processed.
 
-				uint16_t:		Check if there is any input from the user. The SDL_Event data2 type is a promise to filled with the user input.
 				uint8_t:		Audio is ready to be played. The SDL_Event data2 type is the index into the mixChunk_ to be played.
 				std::string:	The application has encountered and error.
 				ResourcePtr:	The next video frame is ready to be rendered. This event drives the control loop.
 
 				The EventData will be used for the SDL_Event data1 property.
 			*/
-			using EventData = std::variant<std::string, uint8_t, uint16_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
+			using EventData = std::variant<std::string, uint8_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>;
 
 			/** A finite EventData resource pool
 
@@ -123,9 +123,30 @@ namespace i8080_arcade
 
 			/** Event data pool mutex
 
-				event data mutual exclusion between the main thread and the machine thread.
+				Event data mutual exclusion between the main thread and the machine thread.
 			*/
 			std::mutex eventDataMutex_;
+
+			/** Event data pool condition variable
+			
+				Used in conjuction with eventDataMutex_ to wait on all outstanding events to complete. This is required for screen transition (back to rom select)
+				so all video frames can be cleared preventing any stale video frames being rendered.
+
+			*/
+			std::condition_variable eventDataCv_;
+			
+			/** Event data pool atomic flag
+			
+				Used in conjuction with the main thread to wait on all outstanding events to complete. This is required for screen transition (back to rom select)
+				so all video frames can be cleared preventing any stale video frames from being rendered.
+			*/
+			//std::atomic_flag eventDataCv_;;
+
+	        /** The maximum number of events across all pools
+
+    	        This can be increased/decreased depending on requirements.
+        	*/
+        	static constexpr int maxEventData_{ 2 };
 
 			/** Prepare for shut down
 
@@ -191,7 +212,7 @@ namespace i8080_arcade
 				True if meen is to run on a different thread to the main application,
 				false otherwise.
 			*/
-			bool runAsync_{};
+			const bool runAsync_{};
 
 			/** The current screen
 
@@ -199,15 +220,18 @@ namespace i8080_arcade
 			*/
 			Screen screen_{};
 
-			/** Read input form the keyboard
-
-				@param	port	The emulated port to read from.
-				@param	state	The keyboard state.
-
-				@return			A uint8_t bitwise combination informing the rom
-								of the user input.
+			/** The SDL keyboard state
+			
+				This is the return value of the SDL_GetKeyboardState api call.
 			*/
-			uint8_t ReadInputDevice(uint8_t port, const uint8_t* state);
+			const uint8_t* sdlKbState_{};
+
+			/** The shared keyboard state
+			
+				We copy the required keyboard state into this array for non main thead access as we assume to pointer
+				returned from the SDL_GetKeyboardState method (sdlKbState_) should not be accessed from a non main thread.
+			*/
+			std::array<std::atomic_bool, SDL_NUM_SCANCODES> kbState_;
 
 			/** Assign a load or save machine interrupt
 
@@ -221,7 +245,7 @@ namespace i8080_arcade
 
 				@return					The current key state (the key parameter).
 			*/
-			Uint8 SetInterrupt(Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState);
+			Uint8 SetInterrupt(bool key, bool lastKey, meen::ISR isr, bool loadSaveState);
 
 			/** Get event data from the event data pool
 

--- a/source/GlyphRenderer.cpp
+++ b/source/GlyphRenderer.cpp
@@ -26,10 +26,8 @@ namespace i8080_arcade
 {
     void GlyphRenderer::Configure()
     {
-        size_t currPos = 0;
         size_t found = 0;
         size_t lastPos = -1;
-        size_t txtHeight = 0;
 
         // clear all values;
         maxTxtWidth_ = 0;
@@ -39,8 +37,8 @@ namespace i8080_arcade
         do
         {
             found = text_.find('\n', ++lastPos);
-            currPos = found == std::string::npos ? text_.length() : found;
-            txtHeight = (currPos - lastPos) * 8; // 8 - store all heights in uncompressed bytes
+            auto currPos = found == std::string::npos ? text_.length() : found;
+            auto txtHeight = (currPos - lastPos) * 8; // 8 - store all heights in uncompressed bytes
 
             // skip consecutive new lines
             while (currPos + 1 < text_.length() && text_[currPos + 1] == '\n')

--- a/source/MemoryController.cpp
+++ b/source/MemoryController.cpp
@@ -83,7 +83,7 @@ namespace i8080_arcade
     {
         std::string txtToBlit;
 
-        for (auto& jsonRom : jsonRoms)
+        for (const auto& jsonRom : jsonRoms)
         {
             txtToBlit += " " + jsonRom.first + " \n\n\n";
         }

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -33,6 +33,12 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
+    bool RPIoController::buttonPress_[Pin::MAX] = {};
+    bool RPIoController::prevEdgeFall_[Pin::MAX] = {};
+    bool RPIoController::prevEdgeRise_[Pin::MAX] = {};
+    // todo: this needs tp be removed once MEEN is updated with an initialisation handler.
+    bool RPIoController::gpioCallbackRegistered_ = false;
+
     RPIoController::RPIoController(bool runAsync, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr&& backBuffer, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
         : runAsync_{ runAsync }
         , romCount_{ romCount }
@@ -230,19 +236,6 @@ namespace i8080_arcade
         return std::make_error_code(std::errc::not_supported);
     }
 
-    bool RPIoController::ButtonPress(bool button, bool& lastButton)
-    {
-        bool press = false;
-
-        if ((button ^ lastButton) && button)
-        {
-            press = true;
-        }
-
-        lastButton = button;
-        return press;
-    }
-
     uint8_t RPIoController::Read(uint16_t port, [[maybe_unused]] meen::IController* memoryController)
     {
         uint8_t ret = i8080ArcadeIO_->ReadPort(port);
@@ -256,10 +249,14 @@ namespace i8080_arcade
                 // therefore we always set it (0x04) (it will be ignored if no credits exist)
                 ret = 0x08 | 0x04;
 
-                if (ButtonPress(!gpio_get(Pin::K1), lastK1_))
+                if (buttonPress_[Pin::K1] == true)
                 {
                     EventData* eventData = nullptr;
                     screen_ = Screen::RomSelect;
+                    buttonPress_[Pin::K1] = false;
+
+                    // Not used on rom select, displae it
+                    gpio_set_irq_enabled(Pin::K0, GPIO_IRQ_EDGE_FALL | GPIO_IRQ_EDGE_RISE, false);
 
                     if (runAsync_ == true)
                     {
@@ -300,15 +297,15 @@ namespace i8080_arcade
                 {
                     if (ships_ > 0)
                     {
-                        // We want button repeats during gameplay for player movement
-                        ret |= !gpio_get(Pin::K0) * 0x20; // 1P Left
-                        ret |= !gpio_get(Pin::K3) * 0x40; // 1P Right
-                        ret |= ButtonPress(!gpio_get(Pin::K2), lastK2_) * 0x10; // 1P Fire
+                        ret |= (RPIoController::buttonPress_[Pin::K0] * 0x20); // 1P Left
+                        ret |= (RPIoController::buttonPress_[Pin::K3] * 0x40); // 1P Right
+                        ret |= (RPIoController::buttonPress_[Pin::K2] * 0x10); // 1P Fire
                     }
                     else
                     {
-                        if (ButtonPress(!gpio_get(Pin::K0), lastK0_))
+                        if (RPIoController::buttonPress_[Pin::K0] == true)
                         {
+                            buttonPress_[Pin::K0] = false;
                             // Add a credit
                             ret |= 0x01;
                             // Move straight to a 1P game.
@@ -337,17 +334,45 @@ namespace i8080_arcade
             // port 3 bit 4 is extended play, need to increment the ships_ count by one
             if((audio >> 4) & 0x01)
             {
-                //printf("Extra ship!\n");
                 ++ships_;
             }
 
             // port 3 bit 2 is player killed, need to reduce the ships_ count by one
             if((audio >> 2) & 0x01)
             {
-                //printf("Player killed\n");
                 --ships_;
             }
         }
+    }
+
+    void RPIoController::RegisterGpioCallback()
+    {
+        gpio_set_irq_callback([](uint gpio, uint32_t eventMask)
+        {
+            // Ignore consecutive edge rise/fall on the same pin.
+            if ((eventMask & GPIO_IRQ_EDGE_FALL) != 0 && prevEdgeFall_[gpio] == false)
+            {
+                RPIoController::buttonPress_[gpio] = true;
+                // Keep track of the edge fall/rise to prevent spurious falls/rises.
+                RPIoController::prevEdgeFall_[gpio] = true;
+                RPIoController::prevEdgeRise_[gpio] = false;
+            }
+
+            if ((eventMask & GPIO_IRQ_EDGE_RISE) != 0 && prevEdgeRise_[gpio] == false)
+            {
+                RPIoController::buttonPress_[gpio] = false;
+                // keep track of the edge fall/rise to prevent spurious falls/rises.
+                RPIoController::prevEdgeFall_[gpio] = false;
+                RPIoController::prevEdgeRise_[gpio] = true;
+            }
+        });
+
+        // Enable the pin interrupts required for the rom select screen (the initial screen state)
+        gpio_set_irq_enabled(Pin::K0, GPIO_IRQ_EDGE_FALL | GPIO_IRQ_EDGE_RISE, false);
+        gpio_set_irq_enabled(Pin::K1, GPIO_IRQ_EDGE_FALL | GPIO_IRQ_EDGE_RISE, true);
+        gpio_set_irq_enabled(Pin::K2, GPIO_IRQ_EDGE_FALL | GPIO_IRQ_EDGE_RISE, true);
+        gpio_set_irq_enabled(Pin::K3, GPIO_IRQ_EDGE_FALL | GPIO_IRQ_EDGE_RISE, true);
+        irq_set_enabled(IO_IRQ_BANK0, true);
     }
 
     meen::ISR RPIoController::ServiceInterrupts(uint64_t currTime, uint64_t cycles, meen::IController* memoryController)
@@ -359,27 +384,43 @@ namespace i8080_arcade
         {
             case 0:
             {
+                /*
+                    THIS NEEDS TO BE REMOVED ONCE AN INITIALISATION REGISTRATION
+                    HANDLER HAS BEEN ADDED TO MEEN.
+                */
+                if(RPIoController::gpioCallbackRegistered_ == false)
+                {
+                    RPIoController::RegisterGpioCallback();
+                    RPIoController::gpioCallbackRegistered_ = true;
+                }
+
                 if (screen_ == Screen::RomSelect)
                 {
                     // Check button 1 press to trigger a rom load interrupt
-                    if (ButtonPress (!gpio_get(Pin::K1), lastK1_)) // we may need to set a callbcak on the pin since the press could be missed
+                    if (RPIoController::buttonPress_[Pin::K1] == true)
                     {
                         isr = meen::ISR::Load;
                         screen_ = Screen::Gameplay;
                         ships_ = 0;
+                        RPIoController::buttonPress_[Pin::K1] = false;
+                        // Only used for gameplay, enable it
+                        gpio_set_irq_enabled(Pin::K0, GPIO_IRQ_EDGE_FALL  | GPIO_IRQ_EDGE_RISE, true);
                     }
 
-                    if (ButtonPress (!gpio_get(Pin::K2), lastK2_)) // we may need to set a callbcak on the pin since the press could be missed
+                    if(RPIoController::buttonPress_[Pin::K2] == true)
                     {
                         romIndex_ = ++romIndex_ % romCount_;
+                        RPIoController::buttonPress_[Pin::K2] = false;
                     }
 
-                    if (ButtonPress (!gpio_get(Pin::K3), lastK3_)) // we may need to set a callbcak on the pin since the press could be missed
+                    if(RPIoController::buttonPress_[Pin::K3] == true)
                     {
                         if (--romIndex_ < 0)
                         {
                             romIndex_ = romCount_ - 1;
                         }
+
+                        RPIoController::buttonPress_[Pin::K3] = false;
                     }
                 }
                 break;
@@ -593,7 +634,6 @@ namespace i8080_arcade
         }, *eventData);
 
         queue_add_blocking(&eventDataFreeQueue_, static_cast<void*>(&eventData));
-
         return quit;
     }
 

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -22,7 +22,6 @@ SOFTWARE.
 
 #include <assert.h>
 #include <bitset>
-#include <future>
 
 #include "i8080_arcade/MemoryController.h"
 #include "i8080_arcade/SdlIoController.h"
@@ -93,7 +92,10 @@ namespace i8080_arcade
 		},
 		reinterpret_cast<void*>(siEvent_));
 
-		for(int i = 0; i < 2; i++)
+		// Monitor key presses/releases
+		sdlKbState_ = SDL_GetKeyboardState(nullptr);
+
+		for(int i = 0; i < maxEventData_; i++)
 		{
 			eventDataPool_.emplace_back(std::make_unique<EventData>());
 		}
@@ -243,7 +245,7 @@ namespace i8080_arcade
 	}
 
 	// Scan the keyboard for load and save requests
-	Uint8 SDLIoController::SetInterrupt(Uint8 key, Uint8 lastKey, meen::ISR isr, bool loadSaveState)
+	Uint8 SDLIoController::SetInterrupt(bool key, bool lastKey, meen::ISR isr, bool loadSaveState)
 	{
 		if (key ^ lastKey && key)
 		{
@@ -254,47 +256,7 @@ namespace i8080_arcade
 		return key;
 	}
 
-	uint8_t SDLIoController::ReadInputDevice(uint8_t port, const uint8_t* state)
-	{
-		uint8_t value = 0;
-		// We can only load from a save file or save if a rom is currently running (engine will generate an error otherwise)
-		// so we only allow the user to perform these operations when a rom is running only.
-		// (either from the Read method directly (runAsync == false) or via the Read method generating a ReadInput event (runAsync == true)
-		lastR_ = SetInterrupt(state[SDL_SCANCODE_R], lastR_, meen::ISR::Load, true);
-		lastY_ = SetInterrupt(state[SDL_SCANCODE_Y], lastY_, meen::ISR::Save, false);
-
-		if (port == 1)
-		{
-			value = 0x08;
-			value |= (state[SDL_SCANCODE_C] * 0x01); // Credit
-			value |= (state[SDL_SCANCODE_1] * 0x04); // 1P
-			value |= (state[SDL_SCANCODE_2] * 0x02); // 2P
-			value |= (state[SDL_SCANCODE_A] * 0x20); // 1P Left
-			value |= (state[SDL_SCANCODE_S] * 0x10); // 1P Fire
-			value |= (state[SDL_SCANCODE_D] * 0x40); // 1P Right
-		}
-		else if (port == 2)
-		{
-			value |= (state[SDL_SCANCODE_3] * 0x00); // 3 Ships
-			value |= (state[SDL_SCANCODE_4] * 0x01); // 4 Ships
-			value |= (state[SDL_SCANCODE_5] * 0x02); // 5 Ships
-			value |= (state[SDL_SCANCODE_6] * 0x03); // 6 Ships
-			value |= (state[SDL_SCANCODE_T] * 0x04); // Tilt
-			value |= (state[SDL_SCANCODE_E] * 0x08); // Extra Ship at
-			value |= (state[SDL_SCANCODE_J] * 0x20); // 2P Left
-			value |= (state[SDL_SCANCODE_K] * 0x10); // 2P Fire
-			value |= (state[SDL_SCANCODE_L] * 0x40); // 2P Right
-			value |= (state[SDL_SCANCODE_I] * 0x80); // Show coin info
-		}
-		else
-		{
-			printf("Invalid Read Port: %d\n", port);
-		}
-
-		return value;
-	}
-
-	std::variant<std::string, uint8_t, uint16_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>* SDLIoController::GetEventData()
+	std::variant<std::string, uint8_t, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>* SDLIoController::GetEventData()
 	{
 		EventData* eventData = nullptr;
 
@@ -317,53 +279,53 @@ namespace i8080_arcade
 		{
 			if (port == 1 || port == 2)
 			{
-				if (runAsync_ == true)
+				if (kbState_[SDL_SCANCODE_ESCAPE] == false)
 				{
-					auto eventData = GetEventData();
+					lastR_ = SetInterrupt(kbState_[SDL_SCANCODE_R], lastR_, meen::ISR::Load, true);
+					lastY_ = SetInterrupt(kbState_[SDL_SCANCODE_Y], lastY_, meen::ISR::Save, false);
 
-					if (eventData != nullptr)
+					if (port == 1)
 					{
-						// This block isn't ideal as it pushes a request to the main
-						// thread and waits for a result ... I don't think we can
-						// remove this and just perform the else case as I don't think
-						// it is safe to do so with SDL across threads.
-						std::promise<uint16_t> p;
-						SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
-						*eventData = port;
-						e.user.data1 = reinterpret_cast<void*>(eventData);
-						e.user.data2 = reinterpret_cast<void*>(&p);
-						SDL_PushEvent(&e);
-
-						if (quit_ == false)
-						{
-							auto val = p.get_future().get();
-
-							if (val <= 0xFF)
-							{
-								ret = static_cast<uint8_t>(val);
-							}
-							else
-							{
-								screen_ = Screen::RomSelect;
-								// Clear the memory controller ram and frame buffers
-								// We don't use a back buffer with this controller, pass nullptr
-								static_cast<MemoryController*>(controller)->Clear(nullptr);
-							}
-						}
+						ret = 0x08;
+						ret |= (kbState_[SDL_SCANCODE_C] * 0x01); // Credit
+						ret |= (kbState_[SDL_SCANCODE_1] * 0x04); // 1P
+						ret |= (kbState_[SDL_SCANCODE_2] * 0x02); // 2P
+						ret |= (kbState_[SDL_SCANCODE_A] * 0x20); // 1P Left
+						ret |= (kbState_[SDL_SCANCODE_S] * 0x10); // 1P Fire
+						ret |= (kbState_[SDL_SCANCODE_D] * 0x40); // 1P Right
+					}
+					else if (port == 2)
+					{
+						ret |= (kbState_[SDL_SCANCODE_3] * 0x00); // 3 Ships
+						ret |= (kbState_[SDL_SCANCODE_4] * 0x01); // 4 Ships
+						ret |= (kbState_[SDL_SCANCODE_5] * 0x02); // 5 Ships
+						ret |= (kbState_[SDL_SCANCODE_6] * 0x03); // 6 Ships
+						ret |= (kbState_[SDL_SCANCODE_T] * 0x04); // Tilt
+						ret |= (kbState_[SDL_SCANCODE_E] * 0x08); // Extra Ship at
+						ret |= (kbState_[SDL_SCANCODE_J] * 0x20); // 2P Left
+						ret |= (kbState_[SDL_SCANCODE_K] * 0x10); // 2P Fire
+						ret |= (kbState_[SDL_SCANCODE_L] * 0x40); // 2P Right
+						ret |= (kbState_[SDL_SCANCODE_I] * 0x80); // Show coin info
 					}
 					else
 					{
-						printf("Failed to dispatch keyboard read, increase the event data pool size\n");
-						//assert(0);
+						assert(0);
+						printf("Invalid Read Port: %d\n", port);
 					}
 				}
 				else
 				{
-					auto kbState = SDL_GetKeyboardState(nullptr);
-
-					if (kbState[SDL_SCANCODE_ESCAPE] == false)
+					if (runAsync_ == true)
 					{
-						ret = ReadInputDevice(port, kbState);
+						// Wait until all outstanding events have been handled before attempting to clear the memory controller.
+						
+						// This uses a condition variable
+						std::unique_lock<std::mutex> lg(eventDataMutex_);
+						eventDataCv_.wait(lg, [this] { return eventDataPool_.size() == maxEventData_; });
+
+						// This uses std::atomic_flag (not quite right, hence using std:condition_variable
+						//eventDataCv_.wait(false);
+						//eventDataCv_.clear();
 					}
 					else
 					{
@@ -380,7 +342,7 @@ namespace i8080_arcade
 							{
 								// The resource (if it exists) will get returned to the frame pool after the completion of this block
 								auto videoFrame = std::get_if<meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr>(eventData);
-								
+
 								if (videoFrame != nullptr)
 								{
 									*videoFrame = nullptr;
@@ -390,12 +352,12 @@ namespace i8080_arcade
 								eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
 							}
 						}
-
-						screen_ = Screen::RomSelect;
-						// Clear the memory controller ram and frame buffers
-						// We don't use a back buffer with this controller, pass nullptr
-						static_cast<MemoryController*>(controller)->Clear(nullptr);
 					}
+
+					screen_ = Screen::RomSelect;
+					// Clear the memory controller ram and frame buffers.
+					// We don't use a back buffer with this controller, pass nullptr.
+					static_cast<MemoryController*>(controller)->Clear(nullptr);
 				}
 			}
 		}
@@ -546,7 +508,6 @@ namespace i8080_arcade
 	{
 		SDL_Event e;
 		bool quit = false;
-		const auto state = SDL_GetKeyboardState(nullptr);
 		bool eventTriggered = runAsync_ == true ? SDL_WaitEvent(&e) : SDL_PollEvent(&e);
 
 		if (eventTriggered == true)
@@ -560,12 +521,6 @@ namespace i8080_arcade
 					[](const std::string& error)
 					{
 						printf("%s\n", error.c_str());
-						return false;
-					},
-					[this, state, &e](uint16_t port)
-					{
-						auto p = static_cast<std::promise<uint16_t>*>(e.user.data2);
-						state[SDL_SCANCODE_ESCAPE] ? p->set_value(0x100) : p->set_value(ReadInputDevice(port, state));
 						return false;
 					},
 					[this, &e](uint8_t port)
@@ -600,34 +555,11 @@ namespace i8080_arcade
 
 						return false;
 					},
-					[this, state, &e](meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr& videoFrame)
+					[this, &e](meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr& videoFrame)
 					{
-						if (state[SDL_SCANCODE_Q] != 0)
+						if (sdlKbState_[SDL_SCANCODE_Q] != 0)
 						{
 							quit_ = true;
-
-							if (runAsync_ == true)
-							{
-								// We are done with the event data, return it back to the event data pool
-								std::lock_guard<std::mutex> lg(eventDataMutex_);
-
-								while (SDL_PeepEvents(&e, 1, SDL_GETEVENT, siEvent_, siEvent_) > 0)
-								{
-									auto ed = std::bit_cast<EventData*>(e.user.data1);
-									assert(ed != nullptr);
-									auto port = std::get_if<uint16_t>(ed);
-
-									if (port != nullptr)
-									{
-										auto p = static_cast<std::promise<uint8_t>*>(e.user.data2);
-										assert(p != nullptr);
-										p->set_value(0);
-									}
-
-									eventDataPool_.push_back(std::unique_ptr<EventData>(ed));
-								}
-							}
-
 							return true;
 						}
 
@@ -663,20 +595,56 @@ namespace i8080_arcade
 							return key;
 						};
 
-						lastUp_ = scrollIndex(state[SDL_SCANCODE_UP], lastUp_, 1);
-						lastDown_ = scrollIndex(state[SDL_SCANCODE_DOWN], lastDown_, -1);
+						// Copy out the values that will be accessed from a different thread.
+						// (Do it regardless in single threaded mode, its here for demo purposes only)
+						kbState_[SDL_SCANCODE_C] = sdlKbState_[SDL_SCANCODE_C];
+						kbState_[SDL_SCANCODE_1] = sdlKbState_[SDL_SCANCODE_1];
+						kbState_[SDL_SCANCODE_2] = sdlKbState_[SDL_SCANCODE_2];
+						kbState_[SDL_SCANCODE_A] = sdlKbState_[SDL_SCANCODE_A];
+						kbState_[SDL_SCANCODE_S] = sdlKbState_[SDL_SCANCODE_S];
+						kbState_[SDL_SCANCODE_D] = sdlKbState_[SDL_SCANCODE_D];
+						kbState_[SDL_SCANCODE_3] = sdlKbState_[SDL_SCANCODE_3];
+						kbState_[SDL_SCANCODE_4] = sdlKbState_[SDL_SCANCODE_4];
+						kbState_[SDL_SCANCODE_5] = sdlKbState_[SDL_SCANCODE_5];
+						kbState_[SDL_SCANCODE_6] = sdlKbState_[SDL_SCANCODE_6];
+						kbState_[SDL_SCANCODE_T] = sdlKbState_[SDL_SCANCODE_T];
+						kbState_[SDL_SCANCODE_E] = sdlKbState_[SDL_SCANCODE_E];
+						kbState_[SDL_SCANCODE_J] = sdlKbState_[SDL_SCANCODE_J];
+						kbState_[SDL_SCANCODE_K] = sdlKbState_[SDL_SCANCODE_K];
+						kbState_[SDL_SCANCODE_L] = sdlKbState_[SDL_SCANCODE_L];
+						kbState_[SDL_SCANCODE_I] = sdlKbState_[SDL_SCANCODE_I];
+						kbState_[SDL_SCANCODE_R] = sdlKbState_[SDL_SCANCODE_R];
+						kbState_[SDL_SCANCODE_Y] = sdlKbState_[SDL_SCANCODE_Y];
+						kbState_[SDL_SCANCODE_ESCAPE] = sdlKbState_[SDL_SCANCODE_ESCAPE];
+
+						lastUp_ = scrollIndex(sdlKbState_[SDL_SCANCODE_UP], lastUp_, 1);
+						lastDown_ = scrollIndex(sdlKbState_[SDL_SCANCODE_DOWN], lastDown_, -1);
 						// Check to see if the user wants to load a rom.
 						// This will only be acknowledged in ServiceInterrupts if screen_ is RomSelect,
 						// we could check screen_ for RomSelect here, but that would mean screen_ would have
 						// to be atomic.
-						lastReturn_ = SetInterrupt(state[SDL_SCANCODE_RETURN], lastReturn_, meen::ISR::Load, false);
+						lastReturn_ = SetInterrupt(sdlKbState_[SDL_SCANCODE_RETURN], lastReturn_, meen::ISR::Load, false);
 						return false;
 					}
 				}, *eventData);
 
-				// We are done with the event data, return it back to the event data pool
-				std::lock_guard<std::mutex> lg(eventDataMutex_);
-				eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
+				{
+					// We are done with the event data, return it back to the event data pool
+					std::lock_guard<std::mutex> lg(eventDataMutex_);
+					eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
+				}
+				
+				if (runAsync_ == true)
+				{
+					if (sdlKbState_[SDL_SCANCODE_ESCAPE] && eventDataPool_.size() == maxEventData_)
+					{
+						eventDataCv_.notify_one();
+
+						// This uses std::atomic_flag (not quite right, hence using std:condition_variable
+						//eventDataCv_.test_and_set();
+						//eventDataCv_.notify_one();
+					}
+				}
 			}
 			else
 			{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -152,7 +152,7 @@ int main(int argc, char** argv)
 	{
 		JsonDocument json;
 #ifdef ENABLE_MH_RP2040
-		auto toPair = [](uint8_t* s, uint8_t* e)
+		auto toPair = [](uint8_t* s, const uint8_t* e)
 		{
 			return std::pair<uintptr_t, uintptr_t>(std::bit_cast<uintptr_t>(s), e - s);
 		};
@@ -231,10 +231,6 @@ int main(int argc, char** argv)
 		// Create our custom i8080 arcade I/O controller based on a specific configuration.
 		auto ioController = MakeIoController(meen["runAsync"], std::move(backBuffer), jsonRoms.size(), hardware["audio"], hardware["video"]);
 		CHECK_ERROR(!ioController, printf("Failed to create the i/o controller\n"));
-
-		// todo: call a method that will create the event pool
-		// auto err = ioController->MakeEventPool(2);
-		// CHECK_ERROR(err, printf("Failed to create the io controller event pool\n");
 
 		// Set up the custom controllers prior to configuring the machine.
 


### PR DESCRIPTION
The using input handling has been refactored characterised by the following:

- `RPIoController` now registers a gpio callback handler to handle button presses rather than checking the pin instantaneous state. This fixes the issue of pin events being missed.
- The `SDLIoController` now copies out the required keyboard state in the main thread into an atomic array for use on the non-main thread, rather than triggering an event with a promise to the main thread and waiting for it to be fulfilled. 