### PR TITLE
#114 chore: use MEEN OnInit for RPIoController

### DIFF
--- a/include/i8080_arcade/RPIoController.h
+++ b/include/i8080_arcade/RPIoController.h
@@ -84,14 +84,6 @@ namespace i8080_arcade
         */
         static bool prevEdgeRise_[Pin::MAX];
 
-        /** One time callback registration
-
-            TODO: this needs to be removed once an initialisation registration
-                  handler has been added to MEEN.
-
-        */
-        static bool gpioCallbackRegistered_;
-
         /** Output device width
 
             Width in pixels.
@@ -218,16 +210,6 @@ namespace i8080_arcade
         */
         int ships_{};
 
-        /** Button state tracking
-
-            Store the previous state of the buttons to eliminate
-            repeated presses when the button is held down.
-        */
-        bool lastK0_{};
-        bool lastK1_{};
-        bool lastK2_{};
-        bool lastK3_{};
-
         /** The currently selected rom
 
             When the user presses the up and down arrows, this will keep track
@@ -284,11 +266,6 @@ namespace i8080_arcade
         */
         static void SetRegion(uint16_t Xstart, uint16_t Ystart, uint16_t Xend, uint16_t Yend);
 
-        /** One time callback registration for gpio handling
-
-        */
-        static void RegisterGpioCallback();
-
     public:
         /** Initialisation constructor
 
@@ -308,6 +285,11 @@ namespace i8080_arcade
             Free the various required RP2040 objects.
         */
         ~RPIoController();
+
+        /** One time callback registration for gpio handling
+
+        */
+        static void Init();
 
         /** IController Read override
 

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -36,8 +36,6 @@ namespace i8080_arcade
     bool RPIoController::buttonPress_[Pin::MAX] = {};
     bool RPIoController::prevEdgeFall_[Pin::MAX] = {};
     bool RPIoController::prevEdgeRise_[Pin::MAX] = {};
-    // todo: this needs tp be removed once MEEN is updated with an initialisation handler.
-    bool RPIoController::gpioCallbackRegistered_ = false;
 
     RPIoController::RPIoController(bool runAsync, meen_hw::MH_ResourcePool<std::vector<uint8_t>>::ResourcePtr&& backBuffer, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
         : runAsync_{ runAsync }

--- a/source/RPIoController.cpp
+++ b/source/RPIoController.cpp
@@ -345,12 +345,12 @@ namespace i8080_arcade
         }
     }
 
-    void RPIoController::RegisterGpioCallback()
+    void RPIoController::Init()
     {
         gpio_set_irq_callback([](uint gpio, uint32_t eventMask)
         {
             // Ignore consecutive edge rise/fall on the same pin.
-            if ((eventMask & GPIO_IRQ_EDGE_FALL) != 0 && prevEdgeFall_[gpio] == false)
+            if ((eventMask & GPIO_IRQ_EDGE_FALL) != 0 && RPIoController::prevEdgeFall_[gpio] == false)
             {
                 RPIoController::buttonPress_[gpio] = true;
                 // Keep track of the edge fall/rise to prevent spurious falls/rises.
@@ -358,7 +358,7 @@ namespace i8080_arcade
                 RPIoController::prevEdgeRise_[gpio] = false;
             }
 
-            if ((eventMask & GPIO_IRQ_EDGE_RISE) != 0 && prevEdgeRise_[gpio] == false)
+            if ((eventMask & GPIO_IRQ_EDGE_RISE) != 0 && RPIoController::prevEdgeRise_[gpio] == false)
             {
                 RPIoController::buttonPress_[gpio] = false;
                 // keep track of the edge fall/rise to prevent spurious falls/rises.
@@ -384,16 +384,6 @@ namespace i8080_arcade
         {
             case 0:
             {
-                /*
-                    THIS NEEDS TO BE REMOVED ONCE AN INITIALISATION REGISTRATION
-                    HANDLER HAS BEEN ADDED TO MEEN.
-                */
-                if(RPIoController::gpioCallbackRegistered_ == false)
-                {
-                    RPIoController::RegisterGpioCallback();
-                    RPIoController::gpioCallbackRegistered_ = true;
-                }
-
                 if (screen_ == Screen::RomSelect)
                 {
                     // Check button 1 press to trigger a rom load interrupt
@@ -536,7 +526,7 @@ namespace i8080_arcade
         }
 
         auto quit = std::visit(overloaded
-	{
+	    {
             [](const std::string& error)
             {
                 printf("%s\n", error.c_str());

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -294,6 +294,14 @@ int main(int argc, char** argv)
 		machine->AttachIoController(meen::IControllerPtr(std::move(ioController)));
 		machine->AttachMemoryController(meen::IControllerPtr(std::move(memoryController)));
 
+		machine->OnInit([](meen::IController* ioController)
+		{
+#ifdef ENABLE_MH_RP2040
+			RPIoController::Init();
+#endif
+			return meen::errc::no_error;
+		});
+
 		// Will be called from a different thread if the 'runAsync' or 'saveAsync' options are set to true.
 		// This is a simple implementation which will overwrite the previous save file
 #ifndef ENABLE_MH_RP2040

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -297,7 +297,7 @@ int main(int argc, char** argv)
 		machine->OnInit([](meen::IController* ioController)
 		{
 #ifdef ENABLE_MH_RP2040
-			RPIoController::Init();
+			i8080_arcade::RPIoController::Init();
 #endif
 			return meen::errc::no_error;
 		});


### PR DESCRIPTION
Replaced the old method of enabling the gpio irqs by utilising the MEEN OnInit api method.