### PR TITLE
#116 fix: sdl audio rendering improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   `uptime` and `memory usage`.
 * Added rendered Midway/Taito copyright.
 * Refactored the event handling.
+* Improved SDL IO controller audio rendering.
 
 0.6.1 [04/08/24]
 * Added profiles for improved build support.

--- a/include/i8080_arcade/SdlIoController.h
+++ b/include/i8080_arcade/SdlIoController.h
@@ -233,6 +233,15 @@ namespace i8080_arcade
 			*/
 			std::array<std::atomic_bool, SDL_NUM_SCANCODES> kbState_;
 
+			/** Samples that are currently playing.
+			
+				Dedicate an individual channel to each sample (while not all samples can be played at the same time,
+				it just makes things easier).
+
+				@remark		Declare 16 channels as this is what is supported, even though some slots remain unused.
+			*/
+			static std::array<std::atomic_bool, MIX_CHANNELS * 2> channelPlaying_;
+
 			/** Assign a load or save machine interrupt
 
 				Peforms a check of the key once during a key press and release sequence.

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -29,6 +29,8 @@ SOFTWARE.
 
 namespace i8080_arcade
 {
+	std::array<std::atomic_bool, MIX_CHANNELS * 2> SDLIoController::channelPlaying_ = {};
+
     SDLIoController::SDLIoController(bool runAsync, int romCount, const JsonVariantConst audioHardware, const JsonVariantConst videoHardware)
 		: runAsync_{ runAsync }
 		, romCount_{ romCount }
@@ -95,6 +97,11 @@ namespace i8080_arcade
 		// Monitor key presses/releases
 		sdlKbState_ = SDL_GetKeyboardState(nullptr);
 
+		Mix_ChannelFinished([](int channel)
+		{
+			SDLIoController::channelPlaying_[channel] = false;
+		});
+
 		for(int i = 0; i < maxEventData_; i++)
 		{
 			eventDataPool_.emplace_back(std::make_unique<EventData>());
@@ -147,6 +154,16 @@ namespace i8080_arcade
 			mixChunk.emplace_back(chunk);
 			return std::error_code{};
 		};
+		
+		if (audio["sample"].size() != MIX_CHANNELS * 2)
+		{
+			return std::make_error_code(std::errc::invalid_argument);
+		}
+
+		if (Mix_AllocateChannels(audio["sample"].size()) != MIX_CHANNELS * 2)
+		{
+			return std::make_error_code(std::errc::not_supported);
+		}
 
 		for(const auto& sample : audio["sample"].as<JsonArrayConst>())
 		{
@@ -375,15 +392,46 @@ namespace i8080_arcade
 
 			if (eventData != nullptr)
 			{
-				SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
-				*eventData = static_cast<uint8_t>(port);
-				e.user.data1 = reinterpret_cast<void*>(eventData);
-				e.user.data2 = reinterpret_cast<void*>(audio);
-				SDL_PushEvent(&e);
+				// port will either be 3 or 5
+				// when port is 3 index will be 0 and when it is 5 it will be 8
+				// which will give the correct offset into the mixChunk_ array
+				auto offset = (port - 3) << 2;
+
+				for (int i = 0; i < 8; i++)
+				{
+					if ((audio >> i) & 0x01)
+					{
+						// Don't repeat a sample until it has finished
+						if (SDLIoController::channelPlaying_[i + offset] == true)
+						{
+							audio &= ~(0x01 << i);
+						}
+						else
+						{
+							SDLIoController::channelPlaying_[i + offset] = true;
+						}
+					}
+				}
+
+				// We may have turned off all audio, check it again
+				if (audio > 0)
+				{
+					SDL_Event e{ .type = static_cast<Uint32>(siEvent_) };
+					*eventData = static_cast<uint8_t>(port);
+					e.user.data1 = reinterpret_cast<void*>(eventData);
+					e.user.data2 = reinterpret_cast<void*>(audio);
+					SDL_PushEvent(&e);
+				}	
+				else
+				{
+					// We have no audio to send, return the data back to the pool
+					std::lock_guard<std::mutex> lg(eventDataMutex_);
+					eventDataPool_.push_back(std::unique_ptr<EventData>(eventData));
+				}
 			}
 			else
 			{
-				printf("Failed dispatch audio, increase the event data pool size\n");
+				printf("Failed to dispatch audio, increase the event data pool size\n");
 				//assert(0);
 			}
 		}
@@ -528,23 +576,11 @@ namespace i8080_arcade
 
 						for (int i = 0; i < 8; i++)
 						{
-							/*
-								todo: if the audio is ufo, we need to loop it rather than playing the sample again.
-										this should fix the stall in single threaded mode
-
-								if audio.test(i) is ufo and ufo not playing
-									mix play channel (repeat the sample)
-
-								if audio.test(i) != ufo and ufo playing
-									mix play channel (stop the sample)
-							*/
-
 							if (audio.test(i) == true)
 							{
-								[[maybe_unused]] auto busy = Mix_PlayChannel(-1 /* use the next available channel */, mixChunk_[i + offset], 0 /* don't loop (play it once) */);
-								// We are playing 8 (default maximum) samples at the same time, this should not happen!
-								// We are trying to play a track which isn't loaded (an unknown data bit is set?!?!)
-								//assert(mixChunk_[i] == nullptr || busy != -1);
+								[[maybe_unused]] auto busy = Mix_PlayChannel(i + offset /* use a dedicated channel */, mixChunk_[i + offset], 0 /* don't loop (play it once) */);
+								// We have a channel for each sound, so busy should only be -1 when we don't have a sound for that channel
+								assert(mixChunk_[i] == nullptr || busy != -1);
 							}
 						}
 
@@ -675,5 +711,7 @@ namespace i8080_arcade
 	{
 		// We successfully loaded the rom, transition into gameplay.
 		screen_ = Screen::Gameplay;
+		// Reset the internal state of the hardware
+		i8080ArcadeIO_->Reset();
 	}
 } // namespace i8080_arcade

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -626,6 +626,13 @@ namespace i8080_arcade
 							return key;
 						};
 
+						// Halt all channels when returning to the rom select screen
+						if (sdlKbState_[SDL_SCANCODE_ESCAPE] == SDL_TRUE)
+						{
+							// -1: since we don't set any channel tags, use the default
+							Mix_HaltGroup(-1);
+						}
+
 						// Copy out the values that will be accessed from a different thread.
 						// (Do it regardless in single threaded mode, its here for demo purposes only)
 						kbState_[SDL_SCANCODE_C] = sdlKbState_[SDL_SCANCODE_C];

--- a/source/SdlIoController.cpp
+++ b/source/SdlIoController.cpp
@@ -43,6 +43,8 @@ namespace i8080_arcade
 			printf("Failed to initialise SDL");
 		}
 
+		Mix_Init(0);
+
 		window_ = SDL_CreateWindow("meen i8080 arcade",
 								SDL_WINDOWPOS_UNDEFINED,
 								SDL_WINDOWPOS_UNDEFINED,
@@ -126,7 +128,7 @@ namespace i8080_arcade
 		}
 
 		Mix_CloseAudio();
-
+		Mix_Quit();
 		SDL_Quit();
 	}
 


### PR DESCRIPTION
- Use a discrete channel for each audio sample.
- Don't repeat a sample until it has finished playing.